### PR TITLE
Enable dynamic topic display

### DIFF
--- a/templates/dependencies.html
+++ b/templates/dependencies.html
@@ -5,18 +5,16 @@
       rel="stylesheet"
       as="style"
       onload="this.rel='stylesheet'"
-      href="https://fonts.googleapis.com/css2?display=swap&amp;family=Inter%3Awght%40400%3B500%3B700%3B900&amp;family=Noto+Sans%3Awght%40400%3B500%3B700%3B900"
+      href="https://fonts.googleapis.com/css2?display=swap&family=Inter:wght@400;500;700;900&family=Noto+Sans:wght@400;500;700;900"
     />
-
     <title>Stitch Design</title>
     <link rel="icon" type="image/x-icon" href="data:image/x-icon;base64," />
-
     <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
   </head>
   <body>
     <div
       class="relative flex size-full min-h-screen flex-col bg-neutral-50 group/design-root overflow-x-hidden"
-      style="--checkbox-tick-svg: url('data:image/svg+xml,%3csvg viewBox=%270 0 16 16%27 fill=%27rgb(250,250,250)%27 xmlns=%27http://www.w3.org/2000/svg%27%3e%3cpath d=%27M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z%27/%3e%3c/svg%3e'); --select-button-svg: url('data:image/svg+xml,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%2724px%27 height=%2724px%27 fill=%27rgb(115,115,115)%27 viewBox=%270 0 256 256%27%3e%3cpath d=%27M181.66,170.34a8,8,0,0,1,0,11.32l-48,48a8,8,0,0,1-11.32,0l-48-48a8,8,0,0,1,11.32-11.32L128,212.69l42.34-42.35A8,8,0,0,1,181.66,170.34Zm-96-84.68L128,43.31l42.34,42.35a8,8,0,0,0,11.32-11.32l-48-48a8,8,0,0,0-11.32,0l-48,48A8,8,0,0,0,85.66,85.66Z%27%3e%3c/path%3e%3c/svg%3e'); font-family: Inter, &quot;Noto Sans&quot;, sans-serif;"
+      style="--checkbox-tick-svg: url('data:image/svg+xml,%3csvg viewBox=%270 0 16 16%27 fill=%27rgb(250,250,250)%27 xmlns=%27http://www.w3.org/2000/svg%27%3e%3cpath d=%27M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z%27/%3e%3c/svg%3e'); --select-button-svg: url('data:image/svg+xml,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%2724px%27 height=%2724px%27 fill=%27rgb(115,115,115)%27 viewBox=%270 0 256 256%27%3e%3cpath d=%27M181.66,170.34a8,8,0,0,1,0,11.32l-48,48a8,8,0,0,1-11.32,0l-48-48a8,8,0,0,1,11.32-11.32L128,212.69l42.34-42.35A8,8,0,0,1,181.66,170.34Zm-96-84.68L128,43.31l42.34,42.35a8,8,0,0,0,11.32-11.32l-48-48a8,8,0,0,0-11.32,0l-48,48A8,8,0,0,0,85.66,85.66Z%27%3e%3c/path%3e%3c/svg%3e'); font-family: Inter, "Noto Sans", sans-serif;"
     >
       <div class="layout-container flex h-full grow flex-col">
         <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#ededed] px-10 py-3">
@@ -41,427 +39,44 @@
             </p>
             <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
               <label class="flex flex-col min-w-40 flex-1">
-                <select
-                  class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-[#141414] focus:outline-0 focus:ring-0 border border-[#dbdbdb] bg-neutral-50 focus:border-[#dbdbdb] h-14 bg-[image:--select-button-svg] placeholder:text-neutral-500 p-[15px] text-base font-normal leading-normal"
-                >
-                  <option value="one">Select a Course</option>
+                <select id="courseSelect" class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-[#141414] focus:outline-0 focus:ring-0 border border-[#dbdbdb] bg-neutral-50 focus:border-[#dbdbdb] h-14 bg-[image:--select-button-svg] placeholder:text-neutral-500 p-[15px] text-base font-normal leading-normal">
+                  <option value="">Select a Course</option>
                   {% for course in courses %}
-                  <option value="{{ loop.index }}">{{ course }}</option>
+                  <option value="{{ course.id }}">{{ course.name }}</option>
                   {% endfor %}
                 </select>
               </label>
             </div>
             <h2 class="text-[#141414] text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5">Available Topics</h2>
-            <h3 class="text-[#141414] text-lg font-bold leading-tight tracking-[-0.015em] px-4 pb-2 pt-4">Introduction to Programming - CS101</h3>
-            <div class="flex gap-4 bg-neutral-50 px-4 py-3 justify-between">
-              <div class="flex items-start gap-4">
-                <div class="flex size-7 items-center justify-center">
-                  <input
-                    type="checkbox"
-                    class="h-5 w-5 rounded border-[#dbdbdb] border-2 bg-transparent text-black checked:bg-black checked:border-black checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:ring-offset-0 focus:border-[#dbdbdb] focus:outline-none"
-                  />
-                </div>
-                <div class="flex flex-1 flex-col justify-center">
-                  <p class="text-[#141414] text-base font-medium leading-normal">Basic Syntax</p>
-                  <p class="text-neutral-500 text-sm font-normal leading-normal">Subtopic:</p>
-                  <p class="text-neutral-500 text-sm font-normal leading-normal">Add notes here</p>
-                </div>
-              </div>
-              <div class="shrink-0">
-                <div class="flex size-7 items-center justify-center">
-                  <input
-                    type="checkbox"
-                    class="h-5 w-5 rounded border-[#dbdbdb] border-2 bg-transparent text-black checked:bg-black checked:border-black checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:ring-offset-0 focus:border-[#dbdbdb] focus:outline-none"
-                  />
-                </div>
-              </div>
-            </div>
-            <div class="flex gap-4 bg-neutral-50 px-4 py-3 justify-between">
-              <div class="flex items-start gap-4">
-                <div class="flex size-7 items-center justify-center">
-                  <input
-                    type="checkbox"
-                    class="h-5 w-5 rounded border-[#dbdbdb] border-2 bg-transparent text-black checked:bg-black checked:border-black checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:ring-offset-0 focus:border-[#dbdbdb] focus:outline-none"
-                  />
-                </div>
-                <div class="flex flex-1 flex-col justify-center">
-                  <p class="text-[#141414] text-base font-medium leading-normal">Control Structures</p>
-                  <p class="text-neutral-500 text-sm font-normal leading-normal">Subtopic:</p>
-                  <p class="text-neutral-500 text-sm font-normal leading-normal">Add notes here</p>
-                </div>
-              </div>
-              <div class="shrink-0">
-                <div class="flex size-7 items-center justify-center">
-                  <input
-                    type="checkbox"
-                    class="h-5 w-5 rounded border-[#dbdbdb] border-2 bg-transparent text-black checked:bg-black checked:border-black checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:ring-offset-0 focus:border-[#dbdbdb] focus:outline-none"
-                  />
-                </div>
-              </div>
-            </div>
-            <div class="flex gap-4 bg-neutral-50 px-4 py-3 justify-between">
-              <div class="flex items-start gap-4">
-                <div class="flex size-7 items-center justify-center">
-                  <input
-                    type="checkbox"
-                    class="h-5 w-5 rounded border-[#dbdbdb] border-2 bg-transparent text-black checked:bg-black checked:border-black checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:ring-offset-0 focus:border-[#dbdbdb] focus:outline-none"
-                  />
-                </div>
-                <div class="flex flex-1 flex-col justify-center">
-                  <p class="text-[#141414] text-base font-medium leading-normal">Data Types</p>
-                  <p class="text-neutral-500 text-sm font-normal leading-normal">Subtopic:</p>
-                  <p class="text-neutral-500 text-sm font-normal leading-normal">Add notes here</p>
-                </div>
-              </div>
-              <div class="shrink-0">
-                <div class="flex size-7 items-center justify-center">
-                  <input
-                    type="checkbox"
-                    class="h-5 w-5 rounded border-[#dbdbdb] border-2 bg-transparent text-black checked:bg-black checked:border-black checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:ring-offset-0 focus:border-[#dbdbdb] focus:outline-none"
-                  />
-                </div>
-              </div>
-            </div>
-            <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
-              <label class="flex flex-col min-w-40 flex-1">
-                <p class="text-[#141414] text-base font-medium leading-normal pb-2">New topic</p>
-                <input
-                  placeholder="Enter new topic"
-                  class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-[#141414] focus:outline-0 focus:ring-0 border border-[#dbdbdb] bg-neutral-50 focus:border-[#dbdbdb] h-14 placeholder:text-neutral-500 p-[15px] text-base font-normal leading-normal"
-                  value=""
-                />
-              </label>
-            </div>
-            <h3 class="text-[#141414] text-lg font-bold leading-tight tracking-[-0.015em] px-4 pb-2 pt-4">Data Structures and Algorithms - CS201</h3>
-            <div class="flex gap-4 bg-neutral-50 px-4 py-3 justify-between">
-              <div class="flex items-start gap-4">
-                <div class="flex size-7 items-center justify-center">
-                  <input
-                    type="checkbox"
-                    class="h-5 w-5 rounded border-[#dbdbdb] border-2 bg-transparent text-black checked:bg-black checked:border-black checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:ring-offset-0 focus:border-[#dbdbdb] focus:outline-none"
-                  />
-                </div>
-                <div class="flex flex-1 flex-col justify-center">
-                  <p class="text-[#141414] text-base font-medium leading-normal">Arrays</p>
-                  <p class="text-neutral-500 text-sm font-normal leading-normal">Subtopic:</p>
-                  <p class="text-neutral-500 text-sm font-normal leading-normal">Add notes here</p>
-                </div>
-              </div>
-              <div class="shrink-0">
-                <div class="flex size-7 items-center justify-center">
-                  <input
-                    type="checkbox"
-                    class="h-5 w-5 rounded border-[#dbdbdb] border-2 bg-transparent text-black checked:bg-black checked:border-black checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:ring-offset-0 focus:border-[#dbdbdb] focus:outline-none"
-                  />
-                </div>
-              </div>
-            </div>
-            <div class="flex gap-4 bg-neutral-50 px-4 py-3 justify-between">
-              <div class="flex items-start gap-4">
-                <div class="flex size-7 items-center justify-center">
-                  <input
-                    type="checkbox"
-                    class="h-5 w-5 rounded border-[#dbdbdb] border-2 bg-transparent text-black checked:bg-black checked:border-black checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:ring-offset-0 focus:border-[#dbdbdb] focus:outline-none"
-                  />
-                </div>
-                <div class="flex flex-1 flex-col justify-center">
-                  <p class="text-[#141414] text-base font-medium leading-normal">Linked Lists</p>
-                  <p class="text-neutral-500 text-sm font-normal leading-normal">Subtopic:</p>
-                  <p class="text-neutral-500 text-sm font-normal leading-normal">Add notes here</p>
-                </div>
-              </div>
-              <div class="shrink-0">
-                <div class="flex size-7 items-center justify-center">
-                  <input
-                    type="checkbox"
-                    class="h-5 w-5 rounded border-[#dbdbdb] border-2 bg-transparent text-black checked:bg-black checked:border-black checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:ring-offset-0 focus:border-[#dbdbdb] focus:outline-none"
-                  />
-                </div>
-              </div>
-            </div>
-            <div class="flex gap-4 bg-neutral-50 px-4 py-3 justify-between">
-              <div class="flex items-start gap-4">
-                <div class="flex size-7 items-center justify-center">
-                  <input
-                    type="checkbox"
-                    class="h-5 w-5 rounded border-[#dbdbdb] border-2 bg-transparent text-black checked:bg-black checked:border-black checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:ring-offset-0 focus:border-[#dbdbdb] focus:outline-none"
-                  />
-                </div>
-                <div class="flex flex-1 flex-col justify-center">
-                  <p class="text-[#141414] text-base font-medium leading-normal">Sorting Algorithms</p>
-                  <p class="text-neutral-500 text-sm font-normal leading-normal">Subtopic:</p>
-                  <p class="text-neutral-500 text-sm font-normal leading-normal">Add notes here</p>
-                </div>
-              </div>
-              <div class="shrink-0">
-                <div class="flex size-7 items-center justify-center">
-                  <input
-                    type="checkbox"
-                    class="h-5 w-5 rounded border-[#dbdbdb] border-2 bg-transparent text-black checked:bg-black checked:border-black checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:ring-offset-0 focus:border-[#dbdbdb] focus:outline-none"
-                  />
-                </div>
-              </div>
-            </div>
-            <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
-              <label class="flex flex-col min-w-40 flex-1">
-                <p class="text-[#141414] text-base font-medium leading-normal pb-2">New topic</p>
-                <input
-                  placeholder="Enter new topic"
-                  class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-[#141414] focus:outline-0 focus:ring-0 border border-[#dbdbdb] bg-neutral-50 focus:border-[#dbdbdb] h-14 placeholder:text-neutral-500 p-[15px] text-base font-normal leading-normal"
-                  value=""
-                />
-              </label>
-            </div>
-            <h3 class="text-[#141414] text-lg font-bold leading-tight tracking-[-0.015em] px-4 pb-2 pt-4">Object-Oriented Programming - CS301</h3>
-            <div class="flex gap-4 bg-neutral-50 px-4 py-3 justify-between">
-              <div class="flex items-start gap-4">
-                <div class="flex size-7 items-center justify-center">
-                  <input
-                    type="checkbox"
-                    class="h-5 w-5 rounded border-[#dbdbdb] border-2 bg-transparent text-black checked:bg-black checked:border-black checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:ring-offset-0 focus:border-[#dbdbdb] focus:outline-none"
-                  />
-                </div>
-                <div class="flex flex-1 flex-col justify-center">
-                  <p class="text-[#141414] text-base font-medium leading-normal">Classes and Objects</p>
-                  <p class="text-neutral-500 text-sm font-normal leading-normal">Subtopic:</p>
-                  <p class="text-neutral-500 text-sm font-normal leading-normal">Add notes here</p>
-                </div>
-              </div>
-              <div class="shrink-0">
-                <div class="flex size-7 items-center justify-center">
-                  <input
-                    type="checkbox"
-                    class="h-5 w-5 rounded border-[#dbdbdb] border-2 bg-transparent text-black checked:bg-black checked:border-black checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:ring-offset-0 focus:border-[#dbdbdb] focus:outline-none"
-                  />
-                </div>
-              </div>
-            </div>
-            <div class="flex gap-4 bg-neutral-50 px-4 py-3 justify-between">
-              <div class="flex items-start gap-4">
-                <div class="flex size-7 items-center justify-center">
-                  <input
-                    type="checkbox"
-                    class="h-5 w-5 rounded border-[#dbdbdb] border-2 bg-transparent text-black checked:bg-black checked:border-black checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:ring-offset-0 focus:border-[#dbdbdb] focus:outline-none"
-                  />
-                </div>
-                <div class="flex flex-1 flex-col justify-center">
-                  <p class="text-[#141414] text-base font-medium leading-normal">Inheritance</p>
-                  <p class="text-neutral-500 text-sm font-normal leading-normal">Subtopic:</p>
-                  <p class="text-neutral-500 text-sm font-normal leading-normal">Add notes here</p>
-                </div>
-              </div>
-              <div class="shrink-0">
-                <div class="flex size-7 items-center justify-center">
-                  <input
-                    type="checkbox"
-                    class="h-5 w-5 rounded border-[#dbdbdb] border-2 bg-transparent text-black checked:bg-black checked:border-black checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:ring-offset-0 focus:border-[#dbdbdb] focus:outline-none"
-                  />
-                </div>
-              </div>
-            </div>
-            <div class="flex gap-4 bg-neutral-50 px-4 py-3 justify-between">
-              <div class="flex items-start gap-4">
-                <div class="flex size-7 items-center justify-center">
-                  <input
-                    type="checkbox"
-                    class="h-5 w-5 rounded border-[#dbdbdb] border-2 bg-transparent text-black checked:bg-black checked:border-black checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:ring-offset-0 focus:border-[#dbdbdb] focus:outline-none"
-                  />
-                </div>
-                <div class="flex flex-1 flex-col justify-center">
-                  <p class="text-[#141414] text-base font-medium leading-normal">Polymorphism</p>
-                  <p class="text-neutral-500 text-sm font-normal leading-normal">Subtopic:</p>
-                  <p class="text-neutral-500 text-sm font-normal leading-normal">Add notes here</p>
-                </div>
-              </div>
-              <div class="shrink-0">
-                <div class="flex size-7 items-center justify-center">
-                  <input
-                    type="checkbox"
-                    class="h-5 w-5 rounded border-[#dbdbdb] border-2 bg-transparent text-black checked:bg-black checked:border-black checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:ring-offset-0 focus:border-[#dbdbdb] focus:outline-none"
-                  />
-                </div>
-              </div>
-            </div>
-            <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
-              <label class="flex flex-col min-w-40 flex-1">
-                <p class="text-[#141414] text-base font-medium leading-normal pb-2">New topic</p>
-                <input
-                  placeholder="Enter new topic"
-                  class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-[#141414] focus:outline-0 focus:ring-0 border border-[#dbdbdb] bg-neutral-50 focus:border-[#dbdbdb] h-14 placeholder:text-neutral-500 p-[15px] text-base font-normal leading-normal"
-                  value=""
-                />
-              </label>
-            </div>
-            <h3 class="text-[#141414] text-lg font-bold leading-tight tracking-[-0.015em] px-4 pb-2 pt-4">Database Management - CS401</h3>
-            <div class="flex gap-4 bg-neutral-50 px-4 py-3 justify-between">
-              <div class="flex items-start gap-4">
-                <div class="flex size-7 items-center justify-center">
-                  <input
-                    type="checkbox"
-                    class="h-5 w-5 rounded border-[#dbdbdb] border-2 bg-transparent text-black checked:bg-black checked:border-black checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:ring-offset-0 focus:border-[#dbdbdb] focus:outline-none"
-                  />
-                </div>
-                <div class="flex flex-1 flex-col justify-center">
-                  <p class="text-[#141414] text-base font-medium leading-normal">SQL Basics</p>
-                  <p class="text-neutral-500 text-sm font-normal leading-normal">Subtopic:</p>
-                  <p class="text-neutral-500 text-sm font-normal leading-normal">Add notes here</p>
-                </div>
-              </div>
-              <div class="shrink-0">
-                <div class="flex size-7 items-center justify-center">
-                  <input
-                    type="checkbox"
-                    class="h-5 w-5 rounded border-[#dbdbdb] border-2 bg-transparent text-black checked:bg-black checked:border-black checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:ring-offset-0 focus:border-[#dbdbdb] focus:outline-none"
-                  />
-                </div>
-              </div>
-            </div>
-            <div class="flex gap-4 bg-neutral-50 px-4 py-3 justify-between">
-              <div class="flex items-start gap-4">
-                <div class="flex size-7 items-center justify-center">
-                  <input
-                    type="checkbox"
-                    class="h-5 w-5 rounded border-[#dbdbdb] border-2 bg-transparent text-black checked:bg-black checked:border-black checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:ring-offset-0 focus:border-[#dbdbdb] focus:outline-none"
-                  />
-                </div>
-                <div class="flex flex-1 flex-col justify-center">
-                  <p class="text-[#141414] text-base font-medium leading-normal">Database Design</p>
-                  <p class="text-neutral-500 text-sm font-normal leading-normal">Subtopic:</p>
-                  <p class="text-neutral-500 text-sm font-normal leading-normal">Add notes here</p>
-                </div>
-              </div>
-              <div class="shrink-0">
-                <div class="flex size-7 items-center justify-center">
-                  <input
-                    type="checkbox"
-                    class="h-5 w-5 rounded border-[#dbdbdb] border-2 bg-transparent text-black checked:bg-black checked:border-black checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:ring-offset-0 focus:border-[#dbdbdb] focus:outline-none"
-                  />
-                </div>
-              </div>
-            </div>
-            <div class="flex gap-4 bg-neutral-50 px-4 py-3 justify-between">
-              <div class="flex items-start gap-4">
-                <div class="flex size-7 items-center justify-center">
-                  <input
-                    type="checkbox"
-                    class="h-5 w-5 rounded border-[#dbdbdb] border-2 bg-transparent text-black checked:bg-black checked:border-black checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:ring-offset-0 focus:border-[#dbdbdb] focus:outline-none"
-                  />
-                </div>
-                <div class="flex flex-1 flex-col justify-center">
-                  <p class="text-[#141414] text-base font-medium leading-normal">Normalization</p>
-                  <p class="text-neutral-500 text-sm font-normal leading-normal">Subtopic:</p>
-                  <p class="text-neutral-500 text-sm font-normal leading-normal">Add notes here</p>
-                </div>
-              </div>
-              <div class="shrink-0">
-                <div class="flex size-7 items-center justify-center">
-                  <input
-                    type="checkbox"
-                    class="h-5 w-5 rounded border-[#dbdbdb] border-2 bg-transparent text-black checked:bg-black checked:border-black checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:ring-offset-0 focus:border-[#dbdbdb] focus:outline-none"
-                  />
-                </div>
-              </div>
-            </div>
-            <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
-              <label class="flex flex-col min-w-40 flex-1">
-                <p class="text-[#141414] text-base font-medium leading-normal pb-2">New topic</p>
-                <input
-                  placeholder="Enter new topic"
-                  class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-[#141414] focus:outline-0 focus:ring-0 border border-[#dbdbdb] bg-neutral-50 focus:border-[#dbdbdb] h-14 placeholder:text-neutral-500 p-[15px] text-base font-normal leading-normal"
-                  value=""
-                />
-              </label>
-            </div>
-            <h3 class="text-[#141414] text-lg font-bold leading-tight tracking-[-0.015em] px-4 pb-2 pt-4">Software Engineering Principles - CS501</h3>
-            <div class="flex gap-4 bg-neutral-50 px-4 py-3 justify-between">
-              <div class="flex items-start gap-4">
-                <div class="flex size-7 items-center justify-center">
-                  <input
-                    type="checkbox"
-                    class="h-5 w-5 rounded border-[#dbdbdb] border-2 bg-transparent text-black checked:bg-black checked:border-black checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:ring-offset-0 focus:border-[#dbdbdb] focus:outline-none"
-                  />
-                </div>
-                <div class="flex flex-1 flex-col justify-center">
-                  <p class="text-[#141414] text-base font-medium leading-normal">Agile Methodologies</p>
-                  <p class="text-neutral-500 text-sm font-normal leading-normal">Subtopic:</p>
-                  <p class="text-neutral-500 text-sm font-normal leading-normal">Add notes here</p>
-                </div>
-              </div>
-              <div class="shrink-0">
-                <div class="flex size-7 items-center justify-center">
-                  <input
-                    type="checkbox"
-                    class="h-5 w-5 rounded border-[#dbdbdb] border-2 bg-transparent text-black checked:bg-black checked:border-black checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:ring-offset-0 focus:border-[#dbdbdb] focus:outline-none"
-                  />
-                </div>
-              </div>
-            </div>
-            <div class="flex gap-4 bg-neutral-50 px-4 py-3 justify-between">
-              <div class="flex items-start gap-4">
-                <div class="flex size-7 items-center justify-center">
-                  <input
-                    type="checkbox"
-                    class="h-5 w-5 rounded border-[#dbdbdb] border-2 bg-transparent text-black checked:bg-black checked:border-black checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:ring-offset-0 focus:border-[#dbdbdb] focus:outline-none"
-                  />
-                </div>
-                <div class="flex flex-1 flex-col justify-center">
-                  <p class="text-[#141414] text-base font-medium leading-normal">Software Testing</p>
-                  <p class="text-neutral-500 text-sm font-normal leading-normal">Subtopic:</p>
-                  <p class="text-neutral-500 text-sm font-normal leading-normal">Add notes here</p>
-                </div>
-              </div>
-              <div class="shrink-0">
-                <div class="flex size-7 items-center justify-center">
-                  <input
-                    type="checkbox"
-                    class="h-5 w-5 rounded border-[#dbdbdb] border-2 bg-transparent text-black checked:bg-black checked:border-black checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:ring-offset-0 focus:border-[#dbdbdb] focus:outline-none"
-                  />
-                </div>
-              </div>
-            </div>
-            <div class="flex gap-4 bg-neutral-50 px-4 py-3 justify-between">
-              <div class="flex items-start gap-4">
-                <div class="flex size-7 items-center justify-center">
-                  <input
-                    type="checkbox"
-                    class="h-5 w-5 rounded border-[#dbdbdb] border-2 bg-transparent text-black checked:bg-black checked:border-black checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:ring-offset-0 focus:border-[#dbdbdb] focus:outline-none"
-                  />
-                </div>
-                <div class="flex flex-1 flex-col justify-center">
-                  <p class="text-[#141414] text-base font-medium leading-normal">Version Control</p>
-                  <p class="text-neutral-500 text-sm font-normal leading-normal">Subtopic:</p>
-                  <p class="text-neutral-500 text-sm font-normal leading-normal">Add notes here</p>
-                </div>
-              </div>
-              <div class="shrink-0">
-                <div class="flex size-7 items-center justify-center">
-                  <input
-                    type="checkbox"
-                    class="h-5 w-5 rounded border-[#dbdbdb] border-2 bg-transparent text-black checked:bg-black checked:border-black checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:ring-offset-0 focus:border-[#dbdbdb] focus:outline-none"
-                  />
-                </div>
-              </div>
-            </div>
-            <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
-              <label class="flex flex-col min-w-40 flex-1">
-                <p class="text-[#141414] text-base font-medium leading-normal pb-2">New topic</p>
-                <input
-                  placeholder="Enter new topic"
-                  class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-[#141414] focus:outline-0 focus:ring-0 border border-[#dbdbdb] bg-neutral-50 focus:border-[#dbdbdb] h-14 placeholder:text-neutral-500 p-[15px] text-base font-normal leading-normal"
-                  value=""
-                />
-              </label>
-            </div>
-            <div class="flex px-4 py-3 justify-end">
-              <button
-                class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-10 px-4 bg-black text-neutral-50 text-sm font-bold leading-normal tracking-[0.015em]"
-              >
-                <span class="truncate">Save Prerequisites</span>
-              </button>
-            </div>
+            <div id="topicsContainer" class="flex flex-col gap-2"></div>
           </div>
         </div>
       </div>
     </div>
+    <script>
+      const courseTopics = {{ course_topics|tojson }};
+      const select = document.getElementById('courseSelect');
+      const container = document.getElementById('topicsContainer');
+      select.addEventListener('change', () => {
+        const topics = courseTopics[select.value] || [];
+        container.innerHTML = '';
+        topics.forEach(topic => {
+          const item = document.createElement('div');
+          item.className = 'flex gap-4 bg-neutral-50 px-4 py-3 justify-between';
+          item.innerHTML = `
+            <div class="flex items-start gap-4">
+              <div class="flex size-7 items-center justify-center">
+                <input type="checkbox" class="h-5 w-5 rounded border-[#dbdbdb] border-2 bg-transparent text-black checked:bg-black checked:border-black checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:ring-offset-0 focus:border-[#dbdbdb] focus:outline-none" />
+              </div>
+              <div class="flex flex-1 flex-col justify-center">
+                <p class="text-[#141414] text-base font-medium leading-normal">${topic}</p>
+                <input placeholder="Subtopic" class="form-input mt-1 flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-[#141414] focus:outline-0 focus:ring-0 border border-[#dbdbdb] bg-neutral-50 focus:border-[#dbdbdb] h-10 placeholder:text-neutral-500 p-[10px] text-sm font-normal leading-normal" />
+                <input placeholder="Add notes here" class="form-input mt-1 flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-[#141414] focus:outline-0 focus:ring-0 border border-[#dbdbdb] bg-neutral-50 focus:border-[#dbdbdb] h-10 placeholder:text-neutral-500 p-[10px] text-sm font-normal leading-normal" />
+              </div>
+            </div>`;
+          container.appendChild(item);
+        });
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- compute topics for each course in `dependencies` route
- drastically simplify `dependencies.html` and display topics dynamically
- remove Save button

## Testing
- `pytest -q`
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6844b38acd14832984f7dd23ff52c39b