### PR TITLE
Introduce Flask-Meld topic component

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,8 +1,12 @@
 from flask import Flask, render_template
+from flask_meld import Meld
 import os
 import yaml
 
 app = Flask(__name__)
+app.config["SECRET_KEY"] = "change-me"
+meld = Meld()
+meld.init_app(app)
 
 @app.route("/")
 def home():

--- a/components/course_topics.py
+++ b/components/course_topics.py
@@ -1,0 +1,15 @@
+from flask_meld import Component
+
+class CourseTopics(Component):
+    """Component for selecting a course and displaying its topics."""
+
+    selected_course = ""
+    topics = []
+    courses = []
+
+    def mount(self, courses, course_topics):
+        self.courses = courses
+        self._course_topics = course_topics
+
+    def updated_selected_course(self, new_id):
+        self.topics = self._course_topics.get(new_id, [])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask==3.0.3
 PyYAML==6.0.1
+flask-meld==0.4.0

--- a/templates/course_topics.html
+++ b/templates/course_topics.html
@@ -1,0 +1,31 @@
+<div>
+  <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
+    <label class="flex flex-col min-w-40 flex-1">
+      <select meld:model="selected_course" class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-[#141414] focus:outline-0 focus:ring-0 border border-[#dbdbdb] bg-neutral-50 focus:border-[#dbdbdb] h-14 bg-[image:--select-button-svg] placeholder:text-neutral-500 p-[15px] text-base font-normal leading-normal">
+        <option value="">Select a Course</option>
+        {% for course in courses %}
+        <option value="{{ course.id }}">{{ course.name }}</option>
+        {% endfor %}
+      </select>
+    </label>
+  </div>
+  {% if topics %}
+  <h2 class="text-[#141414] text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5">Available Topics</h2>
+  <div class="flex flex-col gap-2" id="topicsContainer">
+    {% for topic in topics %}
+    <div class="flex gap-4 bg-neutral-50 px-4 py-3 justify-between">
+      <div class="flex items-start gap-4">
+        <div class="flex size-7 items-center justify-center">
+          <input type="checkbox" class="h-5 w-5 rounded border-[#dbdbdb] border-2 bg-transparent text-black checked:bg-black checked:border-black checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:ring-offset-0 focus:border-[#dbdbdb] focus:outline-none" />
+        </div>
+        <div class="flex flex-1 flex-col justify-center">
+          <p class="text-[#141414] text-base font-medium leading-normal">{{ topic }}</p>
+          <input placeholder="Subtopic" class="form-input mt-1 flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-[#141414] focus:outline-0 focus:ring-0 border border-[#dbdbdb] bg-neutral-50 focus:border-[#dbdbdb] h-10 placeholder:text-neutral-500 p-[10px] text-sm font-normal leading-normal" />
+          <input placeholder="Add notes here" class="form-input mt-1 flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-[#141414] focus:outline-0 focus:ring-0 border border-[#dbdbdb] bg-neutral-50 focus:border-[#dbdbdb] h-10 placeholder:text-neutral-500 p-[10px] text-sm font-normal leading-normal" />
+        </div>
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+  {% endif %}
+</div>

--- a/templates/dependencies.html
+++ b/templates/dependencies.html
@@ -37,46 +37,11 @@
             <p class="text-[#141414] text-base font-normal leading-normal pb-3 pt-1 px-4">
               This page is used to define dependencies between courses. Select a course from the dropdown to view and edit its prerequisites.
             </p>
-            <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
-              <label class="flex flex-col min-w-40 flex-1">
-                <select id="courseSelect" class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-[#141414] focus:outline-0 focus:ring-0 border border-[#dbdbdb] bg-neutral-50 focus:border-[#dbdbdb] h-14 bg-[image:--select-button-svg] placeholder:text-neutral-500 p-[15px] text-base font-normal leading-normal">
-                  <option value="">Select a Course</option>
-                  {% for course in courses %}
-                  <option value="{{ course.id }}">{{ course.name }}</option>
-                  {% endfor %}
-                </select>
-              </label>
-            </div>
-            <h2 class="text-[#141414] text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5">Available Topics</h2>
-            <div id="topicsContainer" class="flex flex-col gap-2"></div>
+            {{ meld.render('course_topics', courses=courses, course_topics=course_topics) }}
           </div>
         </div>
       </div>
     </div>
-    <script>
-      const courseTopics = {{ course_topics|tojson }};
-      const select = document.getElementById('courseSelect');
-      const container = document.getElementById('topicsContainer');
-      select.addEventListener('change', () => {
-        const topics = courseTopics[select.value] || [];
-        container.innerHTML = '';
-        topics.forEach(topic => {
-          const item = document.createElement('div');
-          item.className = 'flex gap-4 bg-neutral-50 px-4 py-3 justify-between';
-          item.innerHTML = `
-            <div class="flex items-start gap-4">
-              <div class="flex size-7 items-center justify-center">
-                <input type="checkbox" class="h-5 w-5 rounded border-[#dbdbdb] border-2 bg-transparent text-black checked:bg-black checked:border-black checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:ring-offset-0 focus:border-[#dbdbdb] focus:outline-none" />
-              </div>
-              <div class="flex flex-1 flex-col justify-center">
-                <p class="text-[#141414] text-base font-medium leading-normal">${topic}</p>
-                <input placeholder="Subtopic" class="form-input mt-1 flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-[#141414] focus:outline-0 focus:ring-0 border border-[#dbdbdb] bg-neutral-50 focus:border-[#dbdbdb] h-10 placeholder:text-neutral-500 p-[10px] text-sm font-normal leading-normal" />
-                <input placeholder="Add notes here" class="form-input mt-1 flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-[#141414] focus:outline-0 focus:ring-0 border border-[#dbdbdb] bg-neutral-50 focus:border-[#dbdbdb] h-10 placeholder:text-neutral-500 p-[10px] text-sm font-normal leading-normal" />
-              </div>
-            </div>`;
-          container.appendChild(item);
-        });
-      });
-    </script>
+    {{ meld.scripts() }}
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add flask-meld dependency
- initialize Meld extension in the app
- replace JS topic handling with a Flask‑Meld component
- show topics only after a course is selected

## Testing
- `python -m py_compile app.py components/course_topics.py`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6844b4b2808c832988c7f61645bbff84