### PR TITLE
Fix typo in OS syllabus

### DIFF
--- a/syllabi/modular/1-Operating Systems (76270).yml
+++ b/syllabi/modular/1-Operating Systems (76270).yml
@@ -4,7 +4,7 @@ course:
   scientific_sector: INFO-01/A
   degree: Bachelor in Computer Science
   semester: 2nd
-  year: 1nd
+  year: 1st
   credits: 9
   modular: true
   total_lecturing_hours: 50


### PR DESCRIPTION
## Summary
- fix year designation in Operating Systems syllabus YAML file

## Testing
- `python3 -m py_compile app.py`
- `python3 - <<'EOF'
import yaml, os
count = 0
for root,_,files in os.walk('syllabi'):
    for f in files:
        if f.endswith('.yml'):
            yaml.safe_load(open(os.path.join(root,f)))
            count+=1
print('loaded', count)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6844b5cb6d708329950b5628cc62b3b1