### PR TITLE
Add filtering by year and semester

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,6 +19,7 @@ def dependencies():
     base_dir = os.path.dirname(__file__)
 
     entries = []
+    years = set()
 
     # Collect standard courses and their topics
     std_dir = os.path.join(base_dir, "syllabi", "standard")
@@ -38,7 +39,10 @@ def dependencies():
                 entries.append({
                     "name": f"{title} ({year} year, {semester} semester)",
                     "topics": topics,
+                    "year": year,
+                    "semester": semester,
                 })
+                years.add(year)
         except Exception:
             continue
 
@@ -71,7 +75,10 @@ def dependencies():
                     entries.append({
                         "name": f"{title} ({year} year, {semester} semester)",
                         "topics": topics,
+                        "year": year,
+                        "semester": semester,
                     })
+                    years.add(year)
         except Exception:
             continue
 
@@ -81,10 +88,22 @@ def dependencies():
     courses = []
     course_topics = {}
     for idx, entry in enumerate(entries, 1):
-        courses.append({"id": str(idx), "name": entry["name"]})
+        courses.append({
+            "id": str(idx),
+            "name": entry["name"],
+            "year": entry["year"],
+            "semester": entry["semester"],
+        })
         course_topics[str(idx)] = entry["topics"]
 
-    return render_template("dependencies.html", courses=courses, course_topics=course_topics)
+    years = sorted(years)
+
+    return render_template(
+        "dependencies.html",
+        courses=courses,
+        course_topics=course_topics,
+        years=years,
+    )
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/components/course_topics.py
+++ b/components/course_topics.py
@@ -3,13 +3,37 @@ from flask_meld import Component
 class CourseTopics(Component):
     """Component for selecting a course and displaying its topics."""
 
+    selected_year = ""
+    selected_semester = ""
     selected_course = ""
     topics = []
     courses = []
+    years = []
 
-    def mount(self, courses, course_topics):
-        self.courses = courses
+    def mount(self, courses, course_topics, years):
+        self._all_courses = courses
+        self.years = years
         self._course_topics = course_topics
+        self.filter_courses()
+
+    def updated_selected_year(self, _):
+        self.selected_course = ""
+        self.filter_courses()
+
+    def updated_selected_semester(self, _):
+        self.selected_course = ""
+        self.filter_courses()
 
     def updated_selected_course(self, new_id):
         self.topics = self._course_topics.get(new_id, [])
+
+    def filter_courses(self):
+        self.courses = [
+            c
+            for c in self._all_courses
+            if (not self.selected_year or c["year"] == self.selected_year)
+            and (not self.selected_semester or c["semester"] == self.selected_semester)
+        ]
+        if not any(c["id"] == self.selected_course for c in self.courses):
+            self.selected_course = ""
+            self.topics = []

--- a/templates/course_topics.html
+++ b/templates/course_topics.html
@@ -1,6 +1,21 @@
 <div>
   <div class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
     <label class="flex flex-col min-w-40 flex-1">
+      <select meld:model="selected_year" class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-[#141414] focus:outline-0 focus:ring-0 border border-[#dbdbdb] bg-neutral-50 focus:border-[#dbdbdb] h-14 bg-[image:--select-button-svg] placeholder:text-neutral-500 p-[15px] text-base font-normal leading-normal">
+        <option value="">Select Year</option>
+        {% for year in years %}
+        <option value="{{ year }}">{{ year }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    <label class="flex flex-col min-w-40 flex-1">
+      <select meld:model="selected_semester" class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-[#141414] focus:outline-0 focus:ring-0 border border-[#dbdbdb] bg-neutral-50 focus:border-[#dbdbdb] h-14 bg-[image:--select-button-svg] placeholder:text-neutral-500 p-[15px] text-base font-normal leading-normal">
+        <option value="">Select Semester</option>
+        <option value="1st">1st</option>
+        <option value="2nd">2nd</option>
+      </select>
+    </label>
+    <label class="flex flex-col min-w-40 flex-1">
       <select meld:model="selected_course" class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-[#141414] focus:outline-0 focus:ring-0 border border-[#dbdbdb] bg-neutral-50 focus:border-[#dbdbdb] h-14 bg-[image:--select-button-svg] placeholder:text-neutral-500 p-[15px] text-base font-normal leading-normal">
         <option value="">Select a Course</option>
         {% for course in courses %}

--- a/templates/dependencies.html
+++ b/templates/dependencies.html
@@ -37,7 +37,7 @@
             <p class="text-[#141414] text-base font-normal leading-normal pb-3 pt-1 px-4">
               This page is used to define dependencies between courses. Select a course from the dropdown to view and edit its prerequisites.
             </p>
-            {{ meld.render('course_topics', courses=courses, course_topics=course_topics) }}
+            {{ meld.render('course_topics', courses=courses, course_topics=course_topics, years=years) }}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- collect available course years
- pass years to CourseTopics component
- filter course list by selected year and semester
- add year and semester dropdowns in the UI

## Testing
- `python -m py_compile app.py components/course_topics.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6844b8033d988329a2f9d8d0538afa57