### PR TITLE
Add course selector and guidance

### DIFF
--- a/app.py
+++ b/app.py
@@ -117,6 +117,7 @@ def dependencies():
     return render_template(
         "dependencies.html",
         courses=filtered_courses,
+        all_courses=courses,
         years=years,
         selected_year=selected_year,
         selected_semester=selected_semester,

--- a/templates/course_topics.html
+++ b/templates/course_topics.html
@@ -1,4 +1,7 @@
 <div>
+  <p class="text-[#141414] text-base font-normal leading-normal pb-3 pt-1 px-4">
+    Please search for the course that covers topics required as prerequisites for the selected course above.
+  </p>
   <form method="get" class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
     <label class="flex flex-col min-w-40 flex-1">
       <select name="year" onchange="this.form.submit()" class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-[#141414] focus:outline-0 focus:ring-0 border border-[#dbdbdb] bg-neutral-50 focus:border-[#dbdbdb] h-14 bg-[image:--select-button-svg] placeholder:text-neutral-500 p-[15px] text-base font-normal leading-normal">

--- a/templates/dependencies.html
+++ b/templates/dependencies.html
@@ -37,6 +37,19 @@
             <p class="text-[#141414] text-base font-normal leading-normal pb-3 pt-1 px-4">
               This page is used to define dependencies between courses. Select a course from the dropdown to view and edit its prerequisites.
             </p>
+            <p class="text-[#141414] text-base font-normal leading-normal pb-3 px-4">
+              Please select the course for which you want to define dependencies.
+            </p>
+            <form class="max-w-[480px] px-4 pb-3">
+              <label class="flex flex-col min-w-40 flex-1">
+                <select class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-[#141414] focus:outline-0 focus:ring-0 border border-[#dbdbdb] bg-neutral-50 focus:border-[#dbdbdb] h-14 bg-[image:--select-button-svg] placeholder:text-neutral-500 p-[15px] text-base font-normal leading-normal">
+                  <option value="">Select a Course</option>
+                  {% for course in all_courses %}
+                  <option value="{{ course.id }}">{{ course.name }}</option>
+                  {% endfor %}
+                </select>
+              </label>
+            </form>
             {% include 'course_topics.html' %}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- pass `all_courses` list to dependencies page
- insert global course selection dropdown
- clarify instructions above dropdown filters

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6844bdad2d848329b9ff535d62422bb4