### PR TITLE
Fix YAML wrapping

### DIFF
--- a/app.py
+++ b/app.py
@@ -204,7 +204,7 @@ def handle_add_dependency(data):
     root["depends-on"] = deps
     yaml_data[root_key] = root
     with open(path, "w") as f:
-        yaml.safe_dump(yaml_data, f, sort_keys=False)
+        yaml.safe_dump(yaml_data, f, sort_keys=False, width=float("inf"))
 
     emit("saved", {"ok": True})
 
@@ -262,7 +262,7 @@ def handle_remove_dependency(data):
     root["depends-on"] = deps
     yaml_data[root_key] = root
     with open(path, "w") as f:
-        yaml.safe_dump(yaml_data, f, sort_keys=False)
+        yaml.safe_dump(yaml_data, f, sort_keys=False, width=float("inf"))
     emit("saved", {"ok": True})
 
 
@@ -316,7 +316,7 @@ def handle_update_dependency(data):
     root["depends-on"] = deps
     yaml_data[root_key] = root
     with open(path, "w") as f:
-        yaml.safe_dump(yaml_data, f, sort_keys=False)
+        yaml.safe_dump(yaml_data, f, sort_keys=False, width=float("inf"))
     emit("saved", {"ok": True})
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- prevent PyYAML from wrapping long strings by setting `width=float('inf')`

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6844d068d06083298d8ac273203acc60