### PR TITLE
Refactor modules root

### DIFF
--- a/create_syllabus.py
+++ b/create_syllabus.py
@@ -15,15 +15,19 @@ def load_yaml(files):
     merged = {}
     for file in files:
         with open(file) as f:
-            data = yaml.safe_load(f)
-            if data:
-                merge_dicts(merged, data)
-                includes = data.get("course", {}).get("include", [])
-                for inc in includes:
-                    with open(os.path.abspath(inc)) as inc_file:
-                        inc_data = yaml.safe_load(inc_file)
-                        if inc_data:
-                            merge_dicts(merged, inc_data)
+            data = yaml.safe_load(f) or {}
+
+        merge_dicts(merged, data)
+
+        includes = data.get("course", {}).get("include", [])
+        for idx, inc in enumerate(includes, start=1):
+            with open(os.path.abspath(inc)) as inc_file:
+                inc_data = yaml.safe_load(inc_file) or {}
+
+            if "course" in inc_data:
+                inc_data = {f"module{idx}": inc_data["course"]}
+
+            merge_dicts(merged, inc_data)
     return merged
 
 

--- a/syllabi/modular/modules/1-Operating Systems and Networking (76270A).yml
+++ b/syllabi/modular/modules/1-Operating Systems and Networking (76270A).yml
@@ -1,4 +1,4 @@
-module1:
+course:
   title: Operating Systems and Networking
   code: 76270A
   scientific_sector: INFO-01/A

--- a/syllabi/modular/modules/1-Programming in C (76270B).yml
+++ b/syllabi/modular/modules/1-Programming in C (76270B).yml
@@ -1,4 +1,4 @@
-module2:
+course:
   title: Programming in C
   code: 76270B
   scientific_sector: INFO-01/A

--- a/syllabi/modular/modules/2-Foundations of Artificial Intelligence (76251A).yml
+++ b/syllabi/modular/modules/2-Foundations of Artificial Intelligence (76251A).yml
@@ -1,4 +1,4 @@
-module1:
+course:
   title: Foundations of Artificial Intelligence
   code: 76251A
   scientific_sector: INFO-01/A

--- a/syllabi/modular/modules/2-Intelligent Agents Project (76252B).yml
+++ b/syllabi/modular/modules/2-Intelligent Agents Project (76252B).yml
@@ -1,4 +1,4 @@
-module2:
+course:
   title: Intelligent Agents Project
   code: 76252B
   scientific_sector: IINF-05/A

--- a/syllabi/modular/modules/2-Knowledge Representation (76252A).yml
+++ b/syllabi/modular/modules/2-Knowledge Representation (76252A).yml
@@ -1,4 +1,4 @@
-module1:
+course:
   title: Knowledge Representation
   code: 76252A
   scientific_sector: INFO-01/A

--- a/syllabi/modular/modules/2-Machine Learning in Practice (76251B).yml
+++ b/syllabi/modular/modules/2-Machine Learning in Practice (76251B).yml
@@ -1,4 +1,4 @@
-module2:
+course:
   title: Machine Learning in Practice
   code: 76261B
   scientific_sector: IINF-05/A

--- a/syllabi/modular/modules/2-Software Systems Architecture (76265A).yml
+++ b/syllabi/modular/modules/2-Software Systems Architecture (76265A).yml
@@ -1,4 +1,4 @@
-module1:
+course:
   title: Software Systems Architecture
   code: 76265A
   scientific_sector: IINF-05/A

--- a/syllabi/modular/modules/2-Tools and Techniques for Software Testing (76265B).yml
+++ b/syllabi/modular/modules/2-Tools and Techniques for Software Testing (76265B).yml
@@ -1,4 +1,4 @@
-module2:
+course:
   title: Tools and Techniques for Software Testing
   code: 76265B
   scientific_sector: INFO-01/A

--- a/syllabi/modular/modules/3-Computational Mathematics (76253A).yml
+++ b/syllabi/modular/modules/3-Computational Mathematics (76253A).yml
@@ -1,4 +1,4 @@
-module1:
+course:
   title: Computational Mathematics
   code: 76253A
   scientific_sector: MATH-05/A

--- a/syllabi/modular/modules/3-Engineering of Mobile Systems (76262A).yml
+++ b/syllabi/modular/modules/3-Engineering of Mobile Systems (76262A).yml
@@ -1,4 +1,4 @@
-module1:
+course:
   title: Engineering of Mobile Systems
   code: 76254A
   scientific_sector: INFO-01/A

--- a/syllabi/modular/modules/3-Information Security (76253B).yml
+++ b/syllabi/modular/modules/3-Information Security (76253B).yml
@@ -1,4 +1,4 @@
-module2:
+course:
   title: Information Security
   code: 76253B
   scientific_sector: IINF-05/A

--- a/syllabi/modular/modules/3-Prototyping Physical Interactive Experiences (76262B).yml
+++ b/syllabi/modular/modules/3-Prototyping Physical Interactive Experiences (76262B).yml
@@ -1,4 +1,4 @@
-module2:
+course:
   title: Prototyping Physical Interactive Experiences
   code: 76254B
   scientific_sector: INFO-01/A


### PR DESCRIPTION
## Summary
- rename `module1`/`module2` roots to `course`
- adapt `load_yaml` so includes get mapped back to `module1` and `module2`

## Testing
- `python - <<'PY'
import create_syllabus
files=['syllabi/modular/1-Operating Systems (76270).yml']
data = create_syllabus.load_yaml(files)
print(data['module1']['title'], data['module2']['title'])
PY`

------
https://chatgpt.com/codex/tasks/task_e_68450c1a57dc8329ab473fb4847237ca