### PR TITLE
Fix modular filter in generate.sh

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -32,6 +32,9 @@ done
 mkdir -p "$OUTPUT_DIR"
 
 for yaml_file in "$INPUT_DIR_STANDARD"/*.yml; do
+    if ! grep -q "modular: false" "$yaml_file"; then
+        continue
+    fi
     filename=$(basename "$yaml_file" .yml)
     output_docx="$OUTPUT_DIR/${filename}.docx"
     output_pdf="$OUTPUT_DIR/${filename}.pdf"


### PR DESCRIPTION
## Summary
- filter standard course YAML files by `modular: false`
- ensure trailing newline in `generate.sh`

## Testing
- `pip install -q -r requirements.txt`
- `python3 check_schema.py`

------
https://chatgpt.com/codex/tasks/task_e_684510e3dedc8329a8574f064f3acd93