### PR TITLE
Disable year/semester dropdowns when target not set

### DIFF
--- a/static/dependencies.js
+++ b/static/dependencies.js
@@ -9,6 +9,13 @@ const topicsHeader = document.getElementById('topicsHeader');
 let currentDependencies = [];
 let currentTopics = [];
 
+function updateDropdownState() {
+  const disabled = !targetSelect.value;
+  yearSelect.disabled = disabled;
+  semesterSelect.disabled = disabled;
+  courseSelect.disabled = disabled;
+}
+
 function requestUpdate() {
   socket.emit('filter', {
     year: yearSelect.value,
@@ -151,10 +158,12 @@ courseSelect.addEventListener('change', () => {
   applyDependencies();
 });
 targetSelect.addEventListener('change', () => {
+  updateDropdownState();
   loadDependencies();
   applyDependencies();
 });
 
 document.addEventListener('DOMContentLoaded', () => {
+  updateDropdownState();
   requestUpdate();
 });

--- a/templates/course_topics.html
+++ b/templates/course_topics.html
@@ -4,7 +4,7 @@
   </p>
   <form class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
     <label class="flex flex-col min-w-40 flex-1">
-      <select id="yearSelect" class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-[#141414] focus:outline-0 focus:ring-0 border border-[#dbdbdb] bg-neutral-50 focus:border-[#dbdbdb] h-14 bg-[image:--select-button-svg] placeholder:text-neutral-500 p-[15px] text-base font-normal leading-normal">
+      <select id="yearSelect" class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-[#141414] focus:outline-0 focus:ring-0 border border-[#dbdbdb] bg-neutral-50 focus:border-[#dbdbdb] h-14 bg-[image:--select-button-svg] placeholder:text-neutral-500 p-[15px] text-base font-normal leading-normal" disabled>
         <option value="">Select Year</option>
         {% for year in years %}
         <option value="{{ year }}">{{ year }}</option>
@@ -12,14 +12,14 @@
       </select>
     </label>
     <label class="flex flex-col min-w-40 flex-1">
-      <select id="semesterSelect" class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-[#141414] focus:outline-0 focus:ring-0 border border-[#dbdbdb] bg-neutral-50 focus:border-[#dbdbdb] h-14 bg-[image:--select-button-svg] placeholder:text-neutral-500 p-[15px] text-base font-normal leading-normal">
+      <select id="semesterSelect" class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-[#141414] focus:outline-0 focus:ring-0 border border-[#dbdbdb] bg-neutral-50 focus:border-[#dbdbdb] h-14 bg-[image:--select-button-svg] placeholder:text-neutral-500 p-[15px] text-base font-normal leading-normal" disabled>
         <option value="">Select Semester</option>
         <option value="1st">1st</option>
         <option value="2nd">2nd</option>
       </select>
     </label>
     <label class="flex flex-col min-w-40 flex-1">
-      <select id="courseSelect" class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-[#141414] focus:outline-0 focus:ring-0 border border-[#dbdbdb] bg-neutral-50 focus:border-[#dbdbdb] h-14 bg-[image:--select-button-svg] placeholder:text-neutral-500 p-[15px] text-base font-normal leading-normal">
+      <select id="courseSelect" class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-[#141414] focus:outline-0 focus:ring-0 border border-[#dbdbdb] bg-neutral-50 focus:border-[#dbdbdb] h-14 bg-[image:--select-button-svg] placeholder:text-neutral-500 p-[15px] text-base font-normal leading-normal" disabled>
         <option value="">Select a Course</option>
         {% for course in courses %}
         <option value="{{ course.id }}">{{ course.name }}</option>


### PR DESCRIPTION
## Summary
- disable dependent dropdowns initially in `course_topics.html`
- update `dependencies.js` to enable/disable dependent dropdowns based on target course selection

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`
- `python3 check_schema.py`

------
https://chatgpt.com/codex/tasks/task_e_68454ab9289883299d41e67352d8643d