### PR TITLE
Add course comment support

### DIFF
--- a/app.py
+++ b/app.py
@@ -76,6 +76,28 @@ def modify_dependency(path, course_name, base_topic, sub_topic="", note=""):
     save_yaml(path, yaml_data)
 
 
+def update_comment(path, course_name, comment=""):
+    yaml_data = load_yaml(path)
+    key, root = get_root(yaml_data)
+    deps = root.get("depends-on", [])
+    if not isinstance(deps, list):
+        deps = []
+
+    entry = next((d for d in deps if d.get("course") == course_name), None)
+    if entry is None:
+        entry = {"course": course_name, "topics": []}
+        deps.append(entry)
+
+    if comment:
+        entry["comment"] = comment
+    else:
+        entry.pop("comment", None)
+
+    root["depends-on"] = deps
+    yaml_data[key] = root
+    save_yaml(path, yaml_data)
+
+
 def remove_dependency(path, course_name, base_topic):
     yaml_data = load_yaml(path)
     key, root = get_root(yaml_data)
@@ -89,7 +111,9 @@ def remove_dependency(path, course_name, base_topic):
             if new_topics:
                 dep["topics"] = new_topics
             else:
-                deps.remove(dep)
+                dep.pop("topics", None)
+                if not dep.get("comment"):
+                    deps.remove(dep)
             break
     root["depends-on"] = deps
     yaml_data[key] = root
@@ -302,6 +326,18 @@ def handle_update_dependency(data):
         data.get("sub_topic", ""),
         data.get("note", ""),
     )
+    emit("saved", {"ok": True})
+
+
+@socketio.on("update_comment")
+def handle_update_comment(data):
+    target_id = data.get("target_id")
+    source_id = data.get("source_id")
+    path = COURSE_PATHS.get(target_id)
+    if not path or not source_id:
+        return
+    course_name = COURSE_NAMES.get(source_id, "")
+    update_comment(path, course_name, data.get("comment", ""))
     emit("saved", {"ok": True})
 
 

--- a/static/dependencies.js
+++ b/static/dependencies.js
@@ -6,6 +6,7 @@ const semesterSelect = document.getElementById('semesterSelect');
 const courseSelect = document.getElementById('courseSelect');
 const topicsContainer = document.getElementById('topicsContainer');
 const topicsHeader = document.getElementById('topicsHeader');
+const commentInput = document.getElementById('courseComment');
 let currentDependencies = [];
 let currentTopics = [];
 
@@ -66,13 +67,13 @@ function renderTopics(topics) {
         </div>
         <div class="flex flex-1 flex-col justify-center">
           <p class="text-[#141414] text-base font-medium leading-normal">${t}</p>
-          <input placeholder="Subtopic" class="form-input mt-1 w-[300px] resize-none overflow-hidden rounded-xl text-[#141414] focus:outline-0 focus:ring-0 border border-[#dbdbdb] bg-neutral-50 focus:border-[#dbdbdb] h-10 placeholder:text-neutral-500 p-[10px] text-sm font-normal leading-normal" />
-          <input placeholder="Add notes here" class="form-input mt-1 w-[300px] resize-none overflow-hidden rounded-xl text-[#141414] focus:outline-0 focus:ring-0 border border-[#dbdbdb] bg-neutral-50 focus:border-[#dbdbdb] h-10 placeholder:text-neutral-500 p-[10px] text-sm font-normal leading-normal" />
+          <textarea placeholder="Subtopic" rows="2" class="form-input mt-1 w-[300px] resize-none overflow-hidden rounded-xl text-[#141414] focus:outline-0 focus:ring-0 border border-[#dbdbdb] bg-neutral-50 focus:border-[#dbdbdb] h-20 placeholder:text-neutral-500 p-[10px] text-sm font-normal leading-normal"></textarea>
+          <textarea placeholder="Add notes here" rows="3" class="form-input mt-1 w-[300px] resize-none overflow-hidden rounded-xl text-[#141414] focus:outline-0 focus:ring-0 border border-[#dbdbdb] bg-neutral-50 focus:border-[#dbdbdb] h-24 placeholder:text-neutral-500 p-[10px] text-sm font-normal leading-normal"></textarea>
         </div>
       </div>`;
     const checkbox = wrapper.querySelector('input[type="checkbox"]');
-    const subInput = wrapper.querySelector('input[placeholder="Subtopic"]');
-    const noteInput = wrapper.querySelector('input[placeholder="Add notes here"]');
+    const subInput = wrapper.querySelector('textarea[placeholder="Subtopic"]');
+    const noteInput = wrapper.querySelector('textarea[placeholder="Add notes here"]');
 
     checkbox.addEventListener('change', (e) => {
       if (e.target.checked) {
@@ -122,17 +123,19 @@ function renderTopics(topics) {
 
 function applyDependencies() {
   const courseName = courseSelect.options[courseSelect.selectedIndex]?.textContent || '';
+  commentInput.value = '';
   document.querySelectorAll('#topicsContainer > div').forEach((wrapper) => {
     const base = wrapper.dataset.baseTopic;
     const checkbox = wrapper.querySelector('input[type="checkbox"]');
-    const subInput = wrapper.querySelector('input[placeholder="Subtopic"]');
-    const noteInput = wrapper.querySelector('input[placeholder="Add notes here"]');
+    const subInput = wrapper.querySelector('textarea[placeholder="Subtopic"]');
+    const noteInput = wrapper.querySelector('textarea[placeholder="Add notes here"]');
     checkbox.checked = false;
     wrapper.dataset.storedTopic = base;
     subInput.value = '';
     noteInput.value = '';
     currentDependencies.forEach((dep) => {
       if (dep.course === courseName) {
+        if (dep.comment) commentInput.value = dep.comment;
         (dep.topics || []).forEach((t) => {
           if (t.topic === base) {
             checkbox.checked = true;
@@ -166,4 +169,13 @@ targetSelect.addEventListener('change', () => {
 document.addEventListener('DOMContentLoaded', () => {
   updateDropdownState();
   requestUpdate();
+});
+
+commentInput.addEventListener('blur', () => {
+  if (!targetSelect.value || !courseSelect.value) return;
+  socket.emit('update_comment', {
+    target_id: targetSelect.value,
+    source_id: courseSelect.value,
+    comment: commentInput.value.trim(),
+  });
 });

--- a/templates/course_topics.html
+++ b/templates/course_topics.html
@@ -29,4 +29,11 @@
   </form>
   <h2 id="topicsHeader" class="text-[#141414] text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5" style="display: none;">Available Topics</h2>
   <div class="flex flex-col gap-2" id="topicsContainer"></div>
+  <div class="px-4 py-3">
+    <textarea
+      id="courseComment"
+      placeholder="Add general comments"
+      class="form-input w-full max-w-[480px] resize-none overflow-hidden rounded-xl text-[#141414] focus:outline-0 focus:ring-0 border border-[#dbdbdb] bg-neutral-50 focus:border-[#dbdbdb] h-24 placeholder:text-neutral-500 p-[10px] text-base font-normal leading-normal"
+    ></textarea>
+  </div>
 </div>


### PR DESCRIPTION
## Summary
- add generic comment textarea to dependencies page
- switch note fields to textareas and make them larger
- support saving course-level comments in YAML

## Testing
- `python -m py_compile app.py`
- `python -m py_compile check_schema.py`
- `python -m py_compile create_syllabus.py`


------
https://chatgpt.com/codex/tasks/task_e_68454d62f48483298a4b0bc9c9e74df6