### PR TITLE
Hide comment box without course

### DIFF
--- a/static/dependencies.js
+++ b/static/dependencies.js
@@ -6,6 +6,7 @@ const semesterSelect = document.getElementById('semesterSelect');
 const courseSelect = document.getElementById('courseSelect');
 const topicsContainer = document.getElementById('topicsContainer');
 const topicsHeader = document.getElementById('topicsHeader');
+const commentContainer = document.getElementById('commentContainer');
 const commentInput = document.getElementById('courseComment');
 let currentDependencies = [];
 let currentTopics = [];
@@ -124,6 +125,7 @@ function renderTopics(topics) {
 
 function applyDependencies() {
   const courseName = courseSelect.options[courseSelect.selectedIndex]?.textContent || '';
+  commentContainer.style.display = courseSelect.value ? 'block' : 'none';
   commentInput.value = '';
   document.querySelectorAll('#topicsContainer > div').forEach((wrapper) => {
     const base = wrapper.dataset.baseTopic;

--- a/templates/course_topics.html
+++ b/templates/course_topics.html
@@ -29,7 +29,11 @@
   </form>
   <h2 id="topicsHeader" class="text-[#141414] text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5" style="display: none;">Available Topics</h2>
   <div class="flex flex-col gap-2" id="topicsContainer"></div>
-  <div class="px-4 py-3">
+  <div id="commentContainer" class="px-4 py-3" style="display: none;">
+    <p class="text-[#141414] text-base font-normal leading-normal pb-2">
+      General remark on additional aspects that this course should address, not
+      already covered by the previous topics.
+    </p>
     <textarea
       id="courseComment"
       placeholder="Add general comments"


### PR DESCRIPTION
## Summary
- hide general comment section until a course is chosen
- add explanatory text above the comment box

## Testing
- `python check_schema.py` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6845511d3fd083298250eedb76b8fa09