### PR TITLE
Improve dependencies page layout

### DIFF
--- a/static/dependencies.js
+++ b/static/dependencies.js
@@ -67,10 +67,10 @@ function renderTopics(topics) {
         <div class="flex size-7 items-center justify-center">
           <input type="checkbox" data-topic="${idx + 1}" class="h-5 w-5 rounded border-[#dbdbdb] border-2 bg-transparent text-black checked:bg-black checked:border-black checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:ring-offset-0 focus:border-[#dbdbdb] focus:outline-none" />
         </div>
-        <div class="flex flex-1 flex-col justify-center">
+        <div class="flex flex-1 flex-col md:flex-row md:items-center md:gap-4 justify-center">
           <p class="text-[#141414] text-base font-medium leading-normal">${t}</p>
           <input placeholder="Subtopic" class="form-input mt-1 w-[300px] resize-none overflow-hidden rounded-xl text-[#141414] focus:outline-0 focus:ring-0 border border-[#dbdbdb] bg-neutral-50 focus:border-[#dbdbdb] h-10 placeholder:text-neutral-500 p-[10px] text-sm font-normal leading-normal" />
-          <input placeholder="Add notes here" class="form-input mt-1 w-[300px] resize-none overflow-hidden rounded-xl text-[#141414] focus:outline-0 focus:ring-0 border border-[#dbdbdb] bg-neutral-50 focus:border-[#dbdbdb] h-10 placeholder:text-neutral-500 p-[10px] text-sm font-normal leading-normal" />
+          <input placeholder="Add notes here" class="form-input mt-1 md:mt-0 w-[300px] resize-none overflow-hidden rounded-xl text-[#141414] focus:outline-0 focus:ring-0 border border-[#dbdbdb] bg-neutral-50 focus:border-[#dbdbdb] h-10 placeholder:text-neutral-500 p-[10px] text-sm font-normal leading-normal" />
         </div>
       </div>`;
     const checkbox = wrapper.querySelector('input[type="checkbox"]');

--- a/templates/course_topics.html
+++ b/templates/course_topics.html
@@ -2,7 +2,7 @@
   <p class="text-[#141414] text-base font-normal leading-normal pb-3 pt-1 px-4">
     Please search for the course that covers topics required as prerequisites for the selected course above.
   </p>
-  <form class="flex max-w-[480px] flex-wrap items-end gap-4 px-4 py-3">
+  <form class="flex max-w-[800px] flex-wrap items-end gap-4 px-4 py-3">
     <label class="flex flex-col min-w-40 flex-1">
       <select id="yearSelect" class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-[#141414] focus:outline-0 focus:ring-0 border border-[#dbdbdb] bg-neutral-50 focus:border-[#dbdbdb] h-14 bg-[image:--select-button-svg] placeholder:text-neutral-500 p-[15px] text-base font-normal leading-normal" disabled>
         <option value="">Select Year</option>
@@ -37,7 +37,7 @@
     <textarea
       id="courseComment"
       placeholder="Add general comments"
-      class="form-input w-full max-w-[480px] resize-none overflow-hidden rounded-xl text-[#141414] focus:outline-0 focus:ring-0 border border-[#dbdbdb] bg-neutral-50 focus:border-[#dbdbdb] h-24 placeholder:text-neutral-500 p-[10px] text-base font-normal leading-normal"
+      class="form-input w-full max-w-[800px] resize-none overflow-hidden rounded-xl text-[#141414] focus:outline-0 focus:ring-0 border border-[#dbdbdb] bg-neutral-50 focus:border-[#dbdbdb] h-24 placeholder:text-neutral-500 p-[10px] text-base font-normal leading-normal"
     ></textarea>
   </div>
 </div>

--- a/templates/dependencies.html
+++ b/templates/dependencies.html
@@ -33,14 +33,14 @@
           </div>
         </header>
         <div class="px-40 flex flex-1 justify-center py-5">
-          <div class="layout-content-container flex flex-col max-w-[960px] flex-1">
+          <div class="layout-content-container flex flex-col max-w-[1280px] flex-1">
             <p class="text-[#141414] text-base font-normal leading-normal pb-3 pt-1 px-4">
               This page is used to define dependencies between courses. Select a course from the dropdown to view and edit its prerequisites.
             </p>
             <p class="text-[#141414] text-base font-normal leading-normal pb-3 px-4">
               Please select the course for which you want to define dependencies.
             </p>
-            <form class="max-w-[480px] px-4 pb-3">
+            <form class="max-w-[800px] px-4 pb-3">
               <label class="flex flex-col min-w-40 flex-1">
                 <select id="targetCourse" class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-[#141414] focus:outline-0 focus:ring-0 border border-[#dbdbdb] bg-neutral-50 focus:border-[#dbdbdb] h-14 bg-[image:--select-button-svg] placeholder:text-neutral-500 p-[15px] text-base font-normal leading-normal">
                   <option value="">Select a Course</option>


### PR DESCRIPTION
## Summary
- expand main page width
- make dropdowns share horizontal space
- place notes input next to subtopic input

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6845558032748329abdbedb9b504aee0