### PR TITLE
Add course dependency visualization page

### DIFF
--- a/app.py
+++ b/app.py
@@ -233,9 +233,35 @@ def load_courses():
 load_courses()
 
 
+def dependency_info():
+    """Return list of courses sorted by number of dependencies."""
+    result = []
+    for cid, path in COURSE_PATHS.items():
+        data = load_yaml(path)
+        key, root = get_root(data)
+        deps = root.get("depends-on", [])
+        if not isinstance(deps, list):
+            deps = []
+        result.append(
+            {
+                "name": COURSE_NAMES.get(cid, ""),
+                "topics": COURSE_TOPICS.get(cid, []),
+                "count": len(deps),
+            }
+        )
+    result.sort(key=lambda d: d["count"], reverse=True)
+    return result
+
+
 @app.route("/")
 def home():
     return render_template("index.html", message="Welcome to Flask!")
+
+
+@app.route("/visualize")
+def visualize():
+    info = dependency_info()
+    return render_template("visualize.html", courses=info)
 
 
 @app.route("/dependencies")

--- a/templates/dependencies.html
+++ b/templates/dependencies.html
@@ -26,8 +26,8 @@
           </div>
           <div class="flex flex-1 justify-end gap-8">
             <div class="flex items-center gap-9">
-              <a class="text-[#141414] text-sm font-medium leading-normal" href="#">Home</a>
-              <a class="text-[#141414] text-sm font-medium leading-normal" href="#">Visualize Dependencies</a>
+              <a class="text-[#141414] text-sm font-medium leading-normal" href="/">Home</a>
+              <a class="text-[#141414] text-sm font-medium leading-normal" href="/visualize">Visualize Dependencies</a>
               <a class="text-[#141414] text-sm font-medium leading-normal" href="#">Warnings</a>
             </div>
           </div>

--- a/templates/visualize.html
+++ b/templates/visualize.html
@@ -1,0 +1,50 @@
+<html>
+  <head>
+    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="" />
+    <link rel="stylesheet" as="style" onload="this.rel='stylesheet'" href="https://fonts.googleapis.com/css2?display=swap&family=Inter:wght@400;500;700;900&family=Noto+Sans:wght@400;500;700;900" />
+    <title>Stitch Design</title>
+    <link rel="icon" type="image/x-icon" href="data:image/x-icon;base64," />
+    <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+  </head>
+  <body>
+    <div class="relative flex size-full min-h-screen flex-col bg-white group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;'>
+      <div class="layout-container flex h-full grow flex-col">
+        <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#ededed] px-10 py-3">
+          <div class="flex items-center gap-4 text-[#141414]">
+            <div class="size-4">
+              <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6 6H42L36 24L42 42H6L12 24L6 6Z" fill="currentColor"></path></svg>
+            </div>
+            <h2 class="text-[#141414] text-lg font-bold leading-tight tracking-[-0.015em]">Syllabus</h2>
+          </div>
+          <div class="flex flex-1 justify-end gap-8">
+            <div class="flex items-center gap-9">
+              <a class="text-[#141414] text-sm font-medium leading-normal" href="/">Home</a>
+              <a class="text-[#141414] text-sm font-medium leading-normal" href="/visualize">Visualize Dependencies</a>
+              <a class="text-[#141414] text-sm font-medium leading-normal" href="#">Warnings</a>
+            </div>
+          </div>
+        </header>
+        <div class="px-40 flex flex-1 justify-center py-5">
+          <div class="layout-content-container flex flex-col max-w-[960px] flex-1">
+            <div class="flex flex-wrap justify-between gap-3 p-4">
+              <div class="flex min-w-72 flex-col gap-3">
+                <p class="text-[#111518] tracking-light text-[32px] font-bold leading-tight">Courses</p>
+                <p class="text-[#60768a] text-sm font-normal leading-normal">Explore available courses and their dependencies.</p>
+              </div>
+            </div>
+            {% for course in courses %}
+            <div class="flex gap-4 bg-white px-4 py-3">
+              <div class="flex flex-1 flex-col justify-center">
+                <p class="text-[#111518] text-base font-medium leading-normal">{{ course.name }}</p>
+                {% if course.topics %}
+                <p class="text-[#60768a] text-sm font-normal leading-normal">- {{ course.topics|join(' - ') }}</p>
+                {% endif %}
+              </div>
+            </div>
+            {% endfor %}
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- link navigation to new route
- implement a new `/visualize` route and helper to sort courses by dependency count
- add a page `visualize.html` to display the list of courses in descending order of dependencies

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684566aafbc48329bcc4e1cd84957296