### PR TITLE
Add warnings page with sample messages

### DIFF
--- a/app.py
+++ b/app.py
@@ -308,6 +308,10 @@ def dependencies():
         all_courses=COURSES,
         years=YEARS,
     )
+@app.route("/warnings")
+def warnings():
+    return render_template("warnings.html")
+
 
 
 @socketio.on("filter")

--- a/templates/dependencies.html
+++ b/templates/dependencies.html
@@ -29,7 +29,7 @@
             <a class="text-[#141414] text-sm font-medium leading-normal" href="/">Home</a>
             <a class="text-[#141414] text-sm font-medium leading-normal" href="/dependencies">Define Dependencies</a>
             <a class="text-[#141414] text-sm font-medium leading-normal" href="/visualize">Visualize Dependencies</a>
-            <a class="text-[#141414] text-sm font-medium leading-normal" href="#">Warnings</a>
+            <a class="text-[#141414] text-sm font-medium leading-normal" href="/warnings">Warnings</a>
           </div>
         </div>
       </header>

--- a/templates/warnings.html
+++ b/templates/warnings.html
@@ -36,26 +36,36 @@
         <div class="layout-content-container flex flex-col max-w-[1280px] flex-1">
           <div class="flex flex-wrap justify-between gap-3 p-4">
             <div class="flex min-w-72 flex-col gap-3">
-              <p class="text-[#111518] tracking-light text-[32px] font-bold leading-tight">Visualize Dependencies</p>
-              <p class="text-[#60768a] text-sm font-normal leading-normal">This page shows the dependencies among
-                courses.</p>
+              <p class="text-[#111518] tracking-light text-[32px] font-bold leading-tight">Warnings</p>
+              <p class="text-[#60768a] text-sm font-normal leading-normal">This page lists current warnings and messages.</p>
             </div>
           </div>
-          {% for course in courses %}
-          <div class="flex gap-4 bg-white px-4 py-3">
-            <div class="flex flex-1 flex-col justify-center">
-              <p class="text-[#111518] text-base font-medium leading-normal">{{ course.name }} [{{ course.count }}]</p>
-              {% for topic in course.topics %}
-              {% if topic.courses %}
-              <p class="text-[#60768a] text-sm font-normal leading-normal">- {{ topic.name }}</p>
-              {% for dep in topic.courses %}
-              <p class="ml-4 text-xs text-[#60768a]">{{ dep }}</p>
-              {% endfor %}
-              {% endif %}
-              {% endfor %}
+          <div class="flex flex-col gap-4 p-4">
+            <div class="flex items-start gap-3 rounded-lg border-l-4 border-yellow-400 bg-yellow-50 p-4">
+              <div class="size-5 text-yellow-400">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"/>
+                </svg>
+              </div>
+              <p class="text-sm text-yellow-700">This is a sample warning message.</p>
+            </div>
+            <div class="flex items-start gap-3 rounded-lg border-l-4 border-red-500 bg-red-50 p-4">
+              <div class="size-5 text-red-500">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M9.75 9.75l4.5 4.5m0-4.5l-4.5 4.5M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                </svg>
+              </div>
+              <p class="text-sm text-red-700">This is a sample error message.</p>
+            </div>
+            <div class="flex items-start gap-3 rounded-lg border-l-4 border-blue-500 bg-blue-50 p-4">
+              <div class="size-5 text-blue-500">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z"/>
+                </svg>
+              </div>
+              <p class="text-sm text-blue-700">This is a sample informational message.</p>
             </div>
           </div>
-          {% endfor %}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add `/warnings` route
- link header to warnings
- create `warnings.html` page styled like `visualize.html`
- show sample warning, error, and info messages

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6845b5a0e5b88329bae9d16b4d17d663