### PR TITLE
Add dependency graph and cycle warnings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ bibtexparser
 pybtex
 docx2pdf
 ruamel.yaml==0.18.2
+networkx

--- a/templates/warnings.html
+++ b/templates/warnings.html
@@ -41,30 +41,20 @@
             </div>
           </div>
           <div class="flex flex-col gap-4 p-4">
-            <div class="flex items-start gap-3 rounded-lg border-l-4 border-yellow-400 bg-yellow-50 p-4">
-              <div class="size-5 text-yellow-400">
-                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"/>
-                </svg>
-              </div>
-              <p class="text-sm text-yellow-700">This is a sample warning message.</p>
-            </div>
+            {% if cycles %}
+            {% for cycle in cycles %}
             <div class="flex items-start gap-3 rounded-lg border-l-4 border-red-500 bg-red-50 p-4">
               <div class="size-5 text-red-500">
                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M9.75 9.75l4.5 4.5m0-4.5l-4.5 4.5M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
                 </svg>
               </div>
-              <p class="text-sm text-red-700">This is a sample error message.</p>
+              <p class="text-sm text-red-700">Circular dependency detected: {{ cycle | join(' → ') }} → {{ cycle[0] }}</p>
             </div>
-            <div class="flex items-start gap-3 rounded-lg border-l-4 border-blue-500 bg-blue-50 p-4">
-              <div class="size-5 text-blue-500">
-                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z"/>
-                </svg>
-              </div>
-              <p class="text-sm text-blue-700">This is a sample informational message.</p>
-            </div>
+            {% endfor %}
+            {% else %}
+            <p class="text-sm text-green-700">No circular dependencies found.</p>
+            {% endif %}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- use `networkx` to build a dependency graph
- detect circular dependencies and show them in `warnings.html`
- add `networkx` to requirements

## Testing
- `pip install -q -r requirements.txt`
- `python - <<'PY'
import app
print('courses', len(app.COURSE_NAMES))
print('cycles', app.find_circular_dependencies())
PY`

------
https://chatgpt.com/codex/tasks/task_e_6845b85dbcf88329a1f8bf57fec595b2