### PR TITLE
Implement dependency warnings/errors

### DIFF
--- a/templates/warnings.html
+++ b/templates/warnings.html
@@ -55,6 +55,28 @@
             {% else %}
             <p class="text-sm text-green-700">No circular dependencies found.</p>
             {% endif %}
+
+            {% for error in errors %}
+            <div class="flex items-start gap-3 rounded-lg border-l-4 border-red-500 bg-red-50 p-4">
+              <div class="size-5 text-red-500">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M9.75 9.75l4.5 4.5m0-4.5l-4.5 4.5M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                </svg>
+              </div>
+              <p class="text-sm text-red-700">{{ error }}</p>
+            </div>
+            {% endfor %}
+
+            {% for warning in warnings %}
+            <div class="flex items-start gap-3 rounded-lg border-l-4 border-yellow-500 bg-yellow-50 p-4">
+              <div class="size-5 text-yellow-500">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                </svg>
+              </div>
+              <p class="text-sm text-yellow-700">{{ warning }}</p>
+            </div>
+            {% endfor %}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- flag dependencies pointing to the same semester or to the future
- show new warnings and errors on the warnings page

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6845b97259408329892ca999694dcb20