### PR TITLE
Display subtopics and notes on visualize page

### DIFF
--- a/app.py
+++ b/app.py
@@ -265,7 +265,11 @@ def dependency_info():
                 except (TypeError, ValueError):
                     continue
                 dependents[target_id]["topics"].setdefault(idx, []).append(
-                    COURSE_NAMES.get(src_id, "")
+                    {
+                        "course": COURSE_NAMES.get(src_id, ""),
+                        "sub_topic": t.get("sub-topic", ""),
+                        "note": t.get("note", ""),
+                    }
                 )
 
     # Build final list

--- a/syllabi/2-Data Structures and Algorithms (76243).yml
+++ b/syllabi/2-Data Structures and Algorithms (76243).yml
@@ -61,3 +61,5 @@ course:
   - course: Analysis
     topics:
     - topic: 2
+      sub-topic: Limits
+      note: Key concepts

--- a/syllabi/2-Intelligent Agents Project (76252B).yml
+++ b/syllabi/2-Intelligent Agents Project (76252B).yml
@@ -26,5 +26,7 @@ course:
   - course: Analysis
     topics:
     - topic: 1
+      sub-topic: Integrals
     - topic: 2
+      note: Review prerequisites
     - topic: 3

--- a/templates/visualize.html
+++ b/templates/visualize.html
@@ -49,7 +49,11 @@
               {% if topic.courses %}
               <p class="text-[#60768a] text-sm font-normal leading-normal">- {{ topic.name }}</p>
               {% for dep in topic.courses %}
-              <p class="ml-4 text-xs text-[#60768a]">{{ dep }}</p>
+              <p class="ml-4 text-xs text-[#60768a]">
+                {{ dep.course }}
+                {% if dep.sub_topic %}<span class="text-yellow-600">({{ dep.sub_topic }})</span>{% endif %}
+                {% if dep.note %}<span class="text-yellow-600">({{ dep.note }})</span>{% endif %}
+              </p>
               {% endfor %}
               {% endif %}
               {% endfor %}


### PR DESCRIPTION
## Summary
- show subtopics and notes in dependency_info()
- render subtopic and note on visualization page
- add example subtopics and notes to a few syllabi

## Testing
- `python check_schema.py`

------
https://chatgpt.com/codex/tasks/task_e_6845ba39eb7c8329ac08e38925a7213f