### PR TITLE
Add deletion to visualized dependencies

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template
+from flask import Flask, render_template, request
 from flask_socketio import SocketIO, emit
 import os
 import yaml
@@ -128,6 +128,25 @@ def remove_dependency(path, course_name, base_topic):
                     deps.remove(dep)
             break
     root["depends-on"] = deps
+    yaml_data[key] = root
+    save_yaml(path, yaml_data)
+
+
+def remove_course_dependency(source_name, target_name):
+    """Remove all dependencies on target_name from source_name course."""
+    source_id = next((cid for cid, n in COURSE_NAMES.items() if n == source_name), None)
+    if not source_id:
+        return
+    path = COURSE_PATHS.get(source_id)
+    if not path:
+        return
+    yaml_data = load_yaml(path)
+    key, root = get_root(yaml_data)
+    deps = root.get("depends-on", [])
+    if not isinstance(deps, list):
+        deps = []
+    new_deps = [d for d in deps if d.get("course") != target_name]
+    root["depends-on"] = new_deps
     yaml_data[key] = root
     save_yaml(path, yaml_data)
 
@@ -273,12 +292,20 @@ def dependency_info():
     for cid in COURSE_PATHS.keys():
         topics_data = []
         for idx, topic_name in enumerate(COURSE_TOPICS.get(cid, []), 1):
-            deps = dependents[cid]["topics"].get(idx, [])
-            topics_data.append({"name": topic_name, "courses": deps})
+            dep_names = dependents[cid]["topics"].get(idx, [])
+            topics_data.append(
+                {
+                    "name": topic_name,
+                    "courses": [
+                        {"id": name_to_id.get(d, ""), "name": d} for d in dep_names
+                    ],
+                }
+            )
 
         count = len(dependents[cid]["total"])
         result.append(
             {
+                "id": cid,
                 "name": COURSE_NAMES.get(cid, ""),
                 "topics": topics_data,
                 "count": count,
@@ -399,6 +426,13 @@ def warnings():
         warnings=warns,
         errors=errs,
     )
+
+
+@app.route("/remove_course_dependency", methods=["POST"])
+def remove_course_dependency_route():
+    data = request.get_json(force=True)
+    remove_course_dependency(data.get("source"), data.get("target"))
+    return {"ok": True}
 
 
 

--- a/static/dependencies.js
+++ b/static/dependencies.js
@@ -10,6 +10,7 @@ const commentContainer = document.getElementById('commentContainer');
 const commentInput = document.getElementById('courseComment');
 let currentDependencies = [];
 let currentTopics = [];
+let presetCourse = null;
 
 function updateControlBackgrounds(root = document) {
   root
@@ -56,9 +57,14 @@ socket.on('filtered', (data) => {
     const opt = document.createElement('option');
     opt.value = c.id;
     opt.textContent = c.name;
-    if (c.id === data.selected_course) opt.selected = true;
+    if (presetCourse ? c.id === presetCourse : c.id === data.selected_course)
+      opt.selected = true;
     courseSelect.appendChild(opt);
   });
+  if (presetCourse) {
+    courseSelect.value = presetCourse;
+    presetCourse = null;
+  }
   currentTopics = data.topics;
   renderTopics(currentTopics);
   loadDependencies();
@@ -187,9 +193,23 @@ targetSelect.addEventListener('change', () => {
 });
 
 document.addEventListener('DOMContentLoaded', () => {
+  const params = new URLSearchParams(window.location.search);
+  if (params.has('target')) {
+    targetSelect.value = params.get('target');
+  }
+  if (params.has('year')) {
+    yearSelect.value = params.get('year');
+  }
+  if (params.has('semester')) {
+    semesterSelect.value = params.get('semester');
+  }
+  if (params.has('source')) {
+    presetCourse = params.get('source');
+  }
   updateDropdownState();
   requestUpdate();
   updateControlBackgrounds();
+  loadDependencies();
 });
 
 commentInput.addEventListener('blur', () => {

--- a/templates/visualize.html
+++ b/templates/visualize.html
@@ -49,7 +49,11 @@
               {% if topic.courses %}
               <p class="text-[#60768a] text-sm font-normal leading-normal">- {{ topic.name }}</p>
               {% for dep in topic.courses %}
-              <p class="ml-4 text-xs text-[#60768a]">{{ dep }}</p>
+              <div class="ml-4 flex items-center text-xs text-[#60768a]">
+                <span>{{ dep.name }}</span>
+                <button class="ml-2 text-red-600" onclick="deleteDependency('{{ dep.name }}', '{{ course.name }}')">x</button>
+                <a class="ml-2 text-blue-600" href="/dependencies?target={{ dep.id }}&source={{ course.id }}">edit</a>
+              </div>
               {% endfor %}
               {% endif %}
               {% endfor %}
@@ -60,6 +64,16 @@
       </div>
     </div>
   </div>
+  <script>
+    function deleteDependency(source, target) {
+      if (!confirm('Delete this dependency?')) return;
+      fetch('/remove_course_dependency', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ source: source, target: target })
+      }).then(() => location.reload());
+    }
+  </script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- allow deleting dependencies from visualization
- backend route and helper for deleting by course name
- add delete button with confirmation dialog
- add edit links to open dependencies page with selections

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6845bb69dcec832991bdaa46a7b7c58a