### PR TITLE
Fix edit preselect and iconify actions

### DIFF
--- a/static/dependencies.js
+++ b/static/dependencies.js
@@ -64,6 +64,7 @@ socket.on('filtered', (data) => {
   if (presetCourse) {
     courseSelect.value = presetCourse;
     presetCourse = null;
+    courseSelect.dispatchEvent(new Event('change'));
   }
   currentTopics = data.topics;
   renderTopics(currentTopics);

--- a/templates/visualize.html
+++ b/templates/visualize.html
@@ -54,8 +54,16 @@
               
               <div class="ml-4 flex items-center text-xs text-[#60768a]">
                 <span>{{ dep.name }}</span>
-                <button class="ml-2 text-red-600" onclick="deleteDependency('{{ dep.name }}', '{{ course.name }}')">x</button>
-                <a class="ml-2 text-blue-600" href="/dependencies?target={{ dep.id }}&source={{ course.id }}">edit</a>
+                <button class="ml-2 text-red-600" onclick="deleteDependency('{{ dep.name }}', '{{ course.name }}')" aria-label="Delete">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+                <a class="ml-2 text-blue-600" href="/dependencies?target={{ dep.id }}&source={{ course.id }}" aria-label="Edit">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v12a2 2 0 002 2h12a2 2 0 002-2v-5m-5.586-9.414a2 2 0 112.828 2.828L11 13l-4 1 1-4 5.586-5.586z" />
+                  </svg>
+                </a>
               </div>
               <p class="ml-4 text-xs text-[#60768a]">
                 {{ dep.course }}


### PR DESCRIPTION
## Summary
- show pencil and cross icons instead of text in dependency list
- trigger course dropdown behaviour when preselecting a course on load

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6845c049606483298ed19f4e14655c82