### PR TITLE
Update info message on warnings page

### DIFF
--- a/templates/warnings.html
+++ b/templates/warnings.html
@@ -53,7 +53,14 @@
             </div>
             {% endfor %}
             {% else %}
-            <p class="text-sm text-green-700">No circular dependencies found.</p>
+            <div class="flex items-start gap-3 rounded-lg border-l-4 border-blue-500 bg-blue-50 p-4">
+              <div class="size-5 text-blue-500">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z"/>
+                </svg>
+              </div>
+              <p class="text-sm text-blue-700">No circular dependencies found.</p>
+            </div>
             {% endif %}
 
             {% for error in errors %}


### PR DESCRIPTION
## Summary
- format the no circular dependencies message with an info block

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6845c20834c883299a5df677305e980a