### PR TITLE
Add error hiding feature

### DIFF
--- a/static/warnings.js
+++ b/static/warnings.js
@@ -1,24 +1,26 @@
- document.addEventListener('DOMContentLoaded', () => {
-   document.querySelectorAll('input[data-warning]').forEach(cb => {
-     cb.addEventListener('change', () => {
-       const text = cb.dataset.warning;
-       const ignore = cb.checked;
-       fetch('/toggle_warning', {
-         method: 'POST',
-         headers: { 'Content-Type': 'application/json' },
-         body: JSON.stringify({ text, ignore })
-       }).then(() => {
-         const p = cb.parentElement.querySelector('p');
-         if (p) {
-           if (ignore) {
-             p.classList.remove('text-yellow-700');
-             p.classList.add('text-gray-400');
-           } else {
-             p.classList.add('text-yellow-700');
-             p.classList.remove('text-gray-400');
-           }
-         }
-       });
-     });
-   });
- });
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('input[data-warning], input[data-error]').forEach(cb => {
+    cb.addEventListener('change', () => {
+      const text = cb.dataset.warning || cb.dataset.error;
+      const ignore = cb.checked;
+      const url = cb.dataset.warning ? '/toggle_warning' : '/toggle_error';
+      fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text, ignore })
+      }).then(() => {
+        const p = cb.parentElement.querySelector('p');
+        if (p) {
+          const activeClass = cb.dataset.warning ? 'text-yellow-700' : 'text-red-700';
+          if (ignore) {
+            p.classList.remove(activeClass);
+            p.classList.add('text-gray-400');
+          } else {
+            p.classList.add(activeClass);
+            p.classList.remove('text-gray-400');
+          }
+        }
+      });
+    });
+  });
+});

--- a/templates/warnings.html
+++ b/templates/warnings.html
@@ -70,7 +70,8 @@
                   <path stroke-linecap="round" stroke-linejoin="round" d="M9.75 9.75l4.5 4.5m0-4.5l-4.5 4.5M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
                 </svg>
               </div>
-              <p class="text-sm text-red-700">{{ error }}</p>
+              <input type="checkbox" data-error="{{ error.text }}" class="h-5 w-5 mr-2 rounded border-[#dbdbdb] border-2 bg-transparent checked:bg-red-500 checked:border-red-500 checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:outline-none" {% if error.ignored %}checked{% endif %} />
+              <p class="text-sm {% if error.ignored %}text-gray-400{% else %}text-red-700{% endif %}">{{ error.text }}</p>
             </div>
             {% endfor %}
 

--- a/warnings.yml
+++ b/warnings.yml
@@ -1,1 +1,2 @@
 ignore: []
+ignore_errors: []


### PR DESCRIPTION
## Summary
- allow ignoring of dependency errors similar to warnings
- persist ignored errors in `warnings.yml`
- update warnings page to let users hide errors
- support toggling errors via JavaScript

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6845c4b5df388329944fa803844f109f