### PR TITLE
Adjust warning layout and styling

### DIFF
--- a/static/warnings.js
+++ b/static/warnings.js
@@ -9,15 +9,21 @@ document.addEventListener('DOMContentLoaded', () => {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ text, ignore })
       }).then(() => {
-        const p = cb.parentElement.querySelector('p');
+        const wrapper = cb.parentElement;
+        const p = wrapper.querySelector('p');
         if (p) {
-          const activeClass = cb.dataset.warning ? 'text-yellow-700' : 'text-red-700';
+          const activeText = cb.dataset.warning ? 'text-yellow-700' : 'text-red-700';
+          const activeBg = cb.dataset.warning ? 'bg-yellow-50' : 'bg-red-50';
           if (ignore) {
-            p.classList.remove(activeClass);
+            p.classList.remove(activeText);
             p.classList.add('text-gray-400');
+            wrapper.classList.remove(activeBg);
+            wrapper.classList.add('bg-gray-100');
           } else {
-            p.classList.add(activeClass);
+            p.classList.add(activeText);
             p.classList.remove('text-gray-400');
+            wrapper.classList.add(activeBg);
+            wrapper.classList.remove('bg-gray-100');
           }
         }
       });

--- a/templates/warnings.html
+++ b/templates/warnings.html
@@ -64,26 +64,26 @@
             {% endif %}
 
             {% for error in errors %}
-            <div class="flex items-start gap-3 rounded-lg bg-red-50 p-4">
+            <div class="flex items-start gap-3 rounded-lg p-4 {% if error.ignored %}bg-gray-100{% else %}bg-red-50{% endif %}">
               <div class="size-5 text-red-500">
                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M9.75 9.75l4.5 4.5m0-4.5l-4.5 4.5M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
                 </svg>
               </div>
-              <input type="checkbox" data-error="{{ error.text }}" class="h-5 w-5 mr-2 rounded border-[#dbdbdb] border-2 bg-transparent checked:bg-red-500 checked:border-red-500 checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:outline-none" {% if error.ignored %}checked{% endif %} />
-              <p class="text-sm {% if error.ignored %}text-gray-400{% else %}text-red-700{% endif %}">{{ error.text }}</p>
+              <p class="flex-1 text-sm {% if error.ignored %}text-gray-400{% else %}text-red-700{% endif %}">{{ error.text }}</p>
+              <input type="checkbox" data-error="{{ error.text }}" class="h-5 w-5 ml-2 rounded border-[#dbdbdb] border-2 bg-transparent checked:bg-red-500 checked:border-red-500 checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:outline-none" {% if error.ignored %}checked{% endif %} />
             </div>
             {% endfor %}
 
             {% for warning in warnings %}
-            <div class="flex items-start gap-3 rounded-lg bg-yellow-50 p-4">
+            <div class="flex items-start gap-3 rounded-lg p-4 {% if warning.ignored %}bg-gray-100{% else %}bg-yellow-50{% endif %}">
               <div class="size-5 text-yellow-500">
                 <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
                 </svg>
               </div>
-              <input type="checkbox" data-warning="{{ warning.text }}" class="h-5 w-5 mr-2 rounded border-[#dbdbdb] border-2 bg-transparent checked:bg-yellow-500 checked:border-yellow-500 checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:outline-none" {% if warning.ignored %}checked{% endif %} />
-              <p class="text-sm {% if warning.ignored %}text-gray-400{% else %}text-yellow-700{% endif %}">{{ warning.text }}</p>
+              <p class="flex-1 text-sm {% if warning.ignored %}text-gray-400{% else %}text-yellow-700{% endif %}">{{ warning.text }}</p>
+              <input type="checkbox" data-warning="{{ warning.text }}" class="h-5 w-5 ml-2 rounded border-[#dbdbdb] border-2 bg-transparent checked:bg-yellow-500 checked:border-yellow-500 checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:outline-none" {% if warning.ignored %}checked{% endif %} />
             </div>
             {% endfor %}
           </div>


### PR DESCRIPTION
## Summary
- move checkboxes to the end of warning/error items
- gray out warning/error container when hidden
- update JavaScript toggling to handle new greyed-out boxes

## Testing
- `python -m py_compile app.py create_syllabus.py check_schema.py`
- `python -m py_compile components/__init__.py`
- `node -c static/warnings.js`

------
https://chatgpt.com/codex/tasks/task_e_6845c71b39f48329a5745abb1e34f791