### PR TITLE
Add course similarity matrix page

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ pybtex
 docx2pdf
 ruamel.yaml==0.18.2
 networkx
+sentence-transformers
+numpy

--- a/templates/dependencies.html
+++ b/templates/dependencies.html
@@ -29,6 +29,7 @@
             <a class="text-[#141414] text-sm font-medium leading-normal" href="/">Home</a>
             <a class="text-[#141414] text-sm font-medium leading-normal" href="/dependencies">Define Dependencies</a>
             <a class="text-[#141414] text-sm font-medium leading-normal" href="/visualize">Visualize Dependencies</a>
+            <a class="text-[#141414] text-sm font-medium leading-normal" href="/similarity">Course Similarity</a>
             <a class="text-[#141414] text-sm font-medium leading-normal" href="/warnings">Warnings</a>
           </div>
         </div>

--- a/templates/similarity.html
+++ b/templates/similarity.html
@@ -1,0 +1,72 @@
+<html>
+<head>
+  <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="" />
+  <link rel="stylesheet" as="style" onload="this.rel='stylesheet'" href="https://fonts.googleapis.com/css2?display=swap&family=Inter:wght@400;500;700;900&family=Noto+Sans:wght@400;500;700;900" />
+  <title>Syllabus</title>
+  <link rel="icon" type="image/x-icon" href="data:image/x-icon;base64," />
+  <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+</head>
+<body>
+  <div class="relative flex size-full min-h-screen flex-col bg-white group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;'>
+    <div class="layout-container flex h-full grow flex-col">
+      <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#ededed] px-10 py-3">
+        <div class="flex items-center gap-4 text-[#141414]">
+          <div class="size-4">
+            <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M6 6H42L36 24L42 42H6L12 24L6 6Z" fill="currentColor"></path>
+            </svg>
+          </div>
+          <h2 class="text-[#141414] text-lg font-bold leading-tight tracking-[-0.015em]">Syllabus</h2>
+        </div>
+        <div class="flex flex-1 justify-end gap-8">
+          <div class="flex items-center gap-9">
+            <a class="text-[#141414] text-sm font-medium leading-normal" href="/">Home</a>
+            <a class="text-[#141414] text-sm font-medium leading-normal" href="/dependencies">Define Dependencies</a>
+            <a class="text-[#141414] text-sm font-medium leading-normal" href="/visualize">Visualize Dependencies</a>
+            <a class="text-[#141414] text-sm font-medium leading-normal" href="/similarity">Course Similarity</a>
+            <a class="text-[#141414] text-sm font-medium leading-normal" href="/warnings">Warnings</a>
+          </div>
+        </div>
+      </header>
+      <div class="px-40 flex flex-1 justify-center py-5">
+        <div class="layout-content-container flex flex-col max-w-[1280px] flex-1">
+          <div class="flex flex-wrap justify-between gap-3 p-4">
+            <div class="flex min-w-72 flex-col gap-3">
+              <p class="text-[#111518] tracking-light text-[32px] font-bold leading-tight">Course Similarity</p>
+              <p class="text-[#60768a] text-sm font-normal leading-normal">This matrix compares courses based on their topics.</p>
+            </div>
+          </div>
+          <div class="overflow-auto">
+            <table class="min-w-full border-collapse text-xs">
+              <thead>
+                <tr>
+                  <th class="border px-2 py-1 text-left"></th>
+                  {% for name in courses %}
+                  <th class="border px-2 py-1 text-left">{{ name }}</th>
+                  {% endfor %}
+                </tr>
+              </thead>
+              <tbody>
+                {% for row_name, row in zip(courses, matrix) %}
+                <tr>
+                  <th class="border px-2 py-1 text-left whitespace-nowrap">{{ row_name }}</th>
+                  {% for value in row %}
+                  {% if value > 0.8 %}
+                  <td class="border px-2 py-1 text-center bg-red-300">{{ '%.2f' % value }}</td>
+                  {% elif value > 0.6 %}
+                  <td class="border px-2 py-1 text-center bg-orange-300">{{ '%.2f' % value }}</td>
+                  {% else %}
+                  <td class="border px-2 py-1 text-center bg-gray-200">{{ '%.2f' % value }}</td>
+                  {% endif %}
+                  {% endfor %}
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/templates/visualize.html
+++ b/templates/visualize.html
@@ -28,6 +28,7 @@
             <a class="text-[#141414] text-sm font-medium leading-normal" href="/">Home</a>
             <a class="text-[#141414] text-sm font-medium leading-normal" href="/dependencies">Define Dependencies</a>
             <a class="text-[#141414] text-sm font-medium leading-normal" href="/visualize">Visualize Dependencies</a>
+            <a class="text-[#141414] text-sm font-medium leading-normal" href="/similarity">Course Similarity</a>
             <a class="text-[#141414] text-sm font-medium leading-normal" href="/warnings">Warnings</a>
           </div>
         </div>

--- a/templates/warnings.html
+++ b/templates/warnings.html
@@ -28,6 +28,7 @@
             <a class="text-[#141414] text-sm font-medium leading-normal" href="/">Home</a>
             <a class="text-[#141414] text-sm font-medium leading-normal" href="/dependencies">Define Dependencies</a>
             <a class="text-[#141414] text-sm font-medium leading-normal" href="/visualize">Visualize Dependencies</a>
+            <a class="text-[#141414] text-sm font-medium leading-normal" href="/similarity">Course Similarity</a>
             <a class="text-[#141414] text-sm font-medium leading-normal" href="/warnings">Warnings</a>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- compute cosine similarity between courses using sentence-transformers
- add `/similarity` route and HTML template with colored matrix
- link the new page from existing navigation bars
- declare `sentence-transformers` and `numpy` in requirements

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- ❌ `pip install sentence-transformers numpy` *(fails: Operation cancelled due to large downloads)*

------
https://chatgpt.com/codex/tasks/task_e_6845e5397c988329a7cb4ea41c537564