### PR TITLE
Add progress indicator and menu redesign

### DIFF
--- a/static/similarity.js
+++ b/static/similarity.js
@@ -4,13 +4,23 @@ const headEl = document.getElementById('simHead');
 const bodyEl = document.getElementById('simBody');
 const tableEl = document.getElementById('simTable');
 const loadingEl = document.getElementById('loading');
+const progressEl = document.getElementById('progress');
 
 socket.on('connect', () => {
   socket.emit('start_similarity');
 });
 
+socket.on('similarity_progress', (data) => {
+  if (progressEl) {
+    progressEl.textContent = data.progress + '%';
+  }
+});
+
 socket.on('similarity_result', (data) => {
   loadingEl.style.display = 'none';
+  if (progressEl) {
+    progressEl.textContent = '100%';
+  }
   tableEl.classList.remove('hidden');
   headEl.innerHTML = '';
   bodyEl.innerHTML = '';

--- a/templates/dependencies.html
+++ b/templates/dependencies.html
@@ -14,25 +14,37 @@
     style="--checkbox-tick-svg: url('data:image/svg+xml,%3csvg viewBox=%270 0 16 16%27 fill=%27rgb(250,250,250)%27 xmlns=%27http://www.w3.org/2000/svg%27%3e%3cpath d=%27M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z%27/%3e%3c/svg%3e'); --select-button-svg: url('data:image/svg+xml,%3csvg xmlns=%27http://www.w3.org/2000/svg%27 width=%2724px%27 height=%2724px%27 fill=%27rgb(115,115,115)%27 viewBox=%270 0 256 256%27%3e%3cpath d=%27M181.66,170.34a8,8,0,0,1,0,11.32l-48,48a8,8,0,0,1-11.32,0l-48-48a8,8,0,0,1,11.32-11.32L128,212.69l42.34-42.35A8,8,0,0,1,181.66,170.34Zm-96-84.68L128,43.31l42.34,42.35a8,8,0,0,0,11.32-11.32l-48-48a8,8,0,0,0-11.32,0l-48,48A8,8,0,0,0,85.66,85.66Z%27%3e%3c/path%3e%3c/svg%3e'); font-family: Inter, "
     Noto Sans", sans-serif;">
     <div class="layout-container flex h-full grow flex-col">
-      <header
-        class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#ededed] px-10 py-3">
+      <header class="flex items-center gap-8 whitespace-nowrap border-b border-solid border-b-[#ededed] px-10 py-3">
         <div class="flex items-center gap-4 text-[#141414]">
           <div class="size-4">
             <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M6 6H42L36 24L42 42H6L12 24L6 6Z" fill="currentColor"></path>
+              <path d="M6 6H42L36 24L42 42H6L12 24L6 6Z" fill="currentColor" />
             </svg>
           </div>
           <h2 class="text-[#141414] text-lg font-bold leading-tight tracking-[-0.015em]">Syllabus</h2>
         </div>
-        <div class="flex flex-1 justify-end gap-8">
-          <div class="flex items-center gap-9">
-            <a class="text-[#141414] text-sm font-medium leading-normal" href="/">Home</a>
-            <a class="text-[#141414] text-sm font-medium leading-normal" href="/dependencies">Define Dependencies</a>
-            <a class="text-[#141414] text-sm font-medium leading-normal" href="/visualize">Visualize Dependencies</a>
-            <a class="text-[#141414] text-sm font-medium leading-normal" href="/similarity">Course Similarity</a>
-            <a class="text-[#141414] text-sm font-medium leading-normal" href="/warnings">Warnings</a>
-          </div>
-        </div>
+        <nav class="flex items-center gap-8">
+          <a class="flex items-center gap-1 text-[#141414] text-sm font-medium leading-normal" href="/">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <span>Home</span>
+          </a>
+          <a class="flex items-center gap-1 text-[#141414] text-sm font-medium leading-normal" href="/dependencies">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
+            <span>Define Dependencies</span>
+          </a>
+          <a class="flex items-center gap-1 text-[#141414] text-sm font-medium leading-normal" href="/visualize">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg>
+            <span>Visualize Dependencies</span>
+          </a>
+          <a class="flex items-center gap-1 text-[#141414] text-sm font-medium leading-normal" href="/similarity">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>
+            <span>Course Similarity</span>
+          </a>
+          <a class="flex items-center gap-1 text-[#141414] text-sm font-medium leading-normal" href="/warnings">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+            <span>Warnings</span>
+          </a>
+        </nav>
       </header>
       <div class="px-40 flex flex-1 justify-center py-5">
         <div class="layout-content-container flex flex-col max-w-[1280px] flex-1">

--- a/templates/similarity.html
+++ b/templates/similarity.html
@@ -9,24 +9,37 @@
 <body>
   <div class="relative flex size-full min-h-screen flex-col bg-white group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;'>
     <div class="layout-container flex h-full grow flex-col">
-      <header class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#ededed] px-10 py-3">
+      <header class="flex items-center gap-8 whitespace-nowrap border-b border-solid border-b-[#ededed] px-10 py-3">
         <div class="flex items-center gap-4 text-[#141414]">
           <div class="size-4">
             <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M6 6H42L36 24L42 42H6L12 24L6 6Z" fill="currentColor"></path>
+              <path d="M6 6H42L36 24L42 42H6L12 24L6 6Z" fill="currentColor" />
             </svg>
           </div>
           <h2 class="text-[#141414] text-lg font-bold leading-tight tracking-[-0.015em]">Syllabus</h2>
         </div>
-        <div class="flex flex-1 justify-end gap-8">
-          <div class="flex items-center gap-9">
-            <a class="text-[#141414] text-sm font-medium leading-normal" href="/">Home</a>
-            <a class="text-[#141414] text-sm font-medium leading-normal" href="/dependencies">Define Dependencies</a>
-            <a class="text-[#141414] text-sm font-medium leading-normal" href="/visualize">Visualize Dependencies</a>
-            <a class="text-[#141414] text-sm font-medium leading-normal" href="/similarity">Course Similarity</a>
-            <a class="text-[#141414] text-sm font-medium leading-normal" href="/warnings">Warnings</a>
-          </div>
-        </div>
+        <nav class="flex items-center gap-8">
+          <a class="flex items-center gap-1 text-[#141414] text-sm font-medium leading-normal" href="/">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <span>Home</span>
+          </a>
+          <a class="flex items-center gap-1 text-[#141414] text-sm font-medium leading-normal" href="/dependencies">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
+            <span>Define Dependencies</span>
+          </a>
+          <a class="flex items-center gap-1 text-[#141414] text-sm font-medium leading-normal" href="/visualize">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg>
+            <span>Visualize Dependencies</span>
+          </a>
+          <a class="flex items-center gap-1 text-[#141414] text-sm font-medium leading-normal" href="/similarity">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>
+            <span>Course Similarity</span>
+          </a>
+          <a class="flex items-center gap-1 text-[#141414] text-sm font-medium leading-normal" href="/warnings">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+            <span>Warnings</span>
+          </a>
+        </nav>
       </header>
       <div class="px-40 flex flex-1 justify-center py-5">
         <div class="layout-content-container flex flex-col max-w-[1280px] flex-1">
@@ -37,7 +50,7 @@
             </div>
           </div>
           <div class="overflow-auto">
-            <div id="loading" class="p-4">Please wait...</div>
+            <div id="loading" class="p-4">Calculating <span id="progress">0%</span></div>
             <table id="simTable" class="min-w-full border-collapse text-xs hidden">
               <thead id="simHead"></thead>
               <tbody id="simBody"></tbody>

--- a/templates/visualize.html
+++ b/templates/visualize.html
@@ -13,25 +13,37 @@
   <div class="relative flex size-full min-h-screen flex-col bg-white group/design-root overflow-x-hidden"
     style='font-family: Inter, "Noto Sans", sans-serif;'>
     <div class="layout-container flex h-full grow flex-col">
-      <header
-        class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#ededed] px-10 py-3">
+      <header class="flex items-center gap-8 whitespace-nowrap border-b border-solid border-b-[#ededed] px-10 py-3">
         <div class="flex items-center gap-4 text-[#141414]">
           <div class="size-4">
             <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M6 6H42L36 24L42 42H6L12 24L6 6Z" fill="currentColor"></path>
+              <path d="M6 6H42L36 24L42 42H6L12 24L6 6Z" fill="currentColor" />
             </svg>
           </div>
           <h2 class="text-[#141414] text-lg font-bold leading-tight tracking-[-0.015em]">Syllabus</h2>
         </div>
-        <div class="flex flex-1 justify-end gap-8">
-          <div class="flex items-center gap-9">
-            <a class="text-[#141414] text-sm font-medium leading-normal" href="/">Home</a>
-            <a class="text-[#141414] text-sm font-medium leading-normal" href="/dependencies">Define Dependencies</a>
-            <a class="text-[#141414] text-sm font-medium leading-normal" href="/visualize">Visualize Dependencies</a>
-            <a class="text-[#141414] text-sm font-medium leading-normal" href="/similarity">Course Similarity</a>
-            <a class="text-[#141414] text-sm font-medium leading-normal" href="/warnings">Warnings</a>
-          </div>
-        </div>
+        <nav class="flex items-center gap-8">
+          <a class="flex items-center gap-1 text-[#141414] text-sm font-medium leading-normal" href="/">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <span>Home</span>
+          </a>
+          <a class="flex items-center gap-1 text-[#141414] text-sm font-medium leading-normal" href="/dependencies">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
+            <span>Define Dependencies</span>
+          </a>
+          <a class="flex items-center gap-1 text-[#141414] text-sm font-medium leading-normal" href="/visualize">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg>
+            <span>Visualize Dependencies</span>
+          </a>
+          <a class="flex items-center gap-1 text-[#141414] text-sm font-medium leading-normal" href="/similarity">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>
+            <span>Course Similarity</span>
+          </a>
+          <a class="flex items-center gap-1 text-[#141414] text-sm font-medium leading-normal" href="/warnings">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+            <span>Warnings</span>
+          </a>
+        </nav>
       </header>
       <div class="px-40 flex flex-1 justify-center py-5">
         <div class="layout-content-container flex flex-col max-w-[1280px] flex-1">

--- a/templates/warnings.html
+++ b/templates/warnings.html
@@ -13,25 +13,37 @@
   <div class="relative flex size-full min-h-screen flex-col bg-white group/design-root overflow-x-hidden"
     style='font-family: Inter, "Noto Sans", sans-serif;'>
     <div class="layout-container flex h-full grow flex-col">
-      <header
-        class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#ededed] px-10 py-3">
+      <header class="flex items-center gap-8 whitespace-nowrap border-b border-solid border-b-[#ededed] px-10 py-3">
         <div class="flex items-center gap-4 text-[#141414]">
           <div class="size-4">
             <svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M6 6H42L36 24L42 42H6L12 24L6 6Z" fill="currentColor"></path>
+              <path d="M6 6H42L36 24L42 42H6L12 24L6 6Z" fill="currentColor" />
             </svg>
           </div>
           <h2 class="text-[#141414] text-lg font-bold leading-tight tracking-[-0.015em]">Syllabus</h2>
         </div>
-        <div class="flex flex-1 justify-end gap-8">
-          <div class="flex items-center gap-9">
-            <a class="text-[#141414] text-sm font-medium leading-normal" href="/">Home</a>
-            <a class="text-[#141414] text-sm font-medium leading-normal" href="/dependencies">Define Dependencies</a>
-            <a class="text-[#141414] text-sm font-medium leading-normal" href="/visualize">Visualize Dependencies</a>
-            <a class="text-[#141414] text-sm font-medium leading-normal" href="/similarity">Course Similarity</a>
-            <a class="text-[#141414] text-sm font-medium leading-normal" href="/warnings">Warnings</a>
-          </div>
-        </div>
+        <nav class="flex items-center gap-8">
+          <a class="flex items-center gap-1 text-[#141414] text-sm font-medium leading-normal" href="/">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            <span>Home</span>
+          </a>
+          <a class="flex items-center gap-1 text-[#141414] text-sm font-medium leading-normal" href="/dependencies">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
+            <span>Define Dependencies</span>
+          </a>
+          <a class="flex items-center gap-1 text-[#141414] text-sm font-medium leading-normal" href="/visualize">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg>
+            <span>Visualize Dependencies</span>
+          </a>
+          <a class="flex items-center gap-1 text-[#141414] text-sm font-medium leading-normal" href="/similarity">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>
+            <span>Course Similarity</span>
+          </a>
+          <a class="flex items-center gap-1 text-[#141414] text-sm font-medium leading-normal" href="/warnings">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+            <span>Warnings</span>
+          </a>
+        </nav>
       </header>
       <div class="px-40 flex flex-1 justify-center py-5">
         <div class="layout-content-container flex flex-col max-w-[1280px] flex-1">


### PR DESCRIPTION
## Summary
- emit progress updates from similarity calculation
- display progress percentage on the Course Similarity page
- move the menu to the left and add icons to each link

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pip install PyYAML`
- `pip install jsonschema`
- `python3 check_schema.py`

------
https://chatgpt.com/codex/tasks/task_e_6845ed8ba750832989ff9826abe3139b