### PR TITLE
Fix alignment and add sticky similarity table headers

### DIFF
--- a/templates/dependencies.html
+++ b/templates/dependencies.html
@@ -11,7 +11,7 @@
     <div class="layout-container flex h-full grow">
       {% include 'sidebar.html' %}
       <div class="flex flex-col flex-1">
-        <div class="px-40 flex flex-1 justify-center py-5">
+        <div class="px-10 flex flex-1 py-5">
           <div class="layout-content-container flex flex-col max-w-[1280px] flex-1">
             <div class="flex flex-wrap justify-between gap-3 p-4">
               <div class="flex min-w-72 flex-col gap-3">

--- a/templates/similarity.html
+++ b/templates/similarity.html
@@ -5,13 +5,31 @@
   <title>Syllabus</title>
   <link rel="icon" type="image/x-icon" href="data:image/x-icon;base64," />
   <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+  <style>
+    #simTable thead th {
+      position: sticky;
+      top: 0;
+      background: white;
+      z-index: 10;
+    }
+    #simTable th:first-child,
+    #simTable td:first-child {
+      position: sticky;
+      left: 0;
+      background: white;
+      z-index: 5;
+    }
+    #simTable thead th:first-child {
+      z-index: 15;
+    }
+  </style>
 </head>
 <body>
   <div class="relative flex size-full min-h-screen flex-col bg-white group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;'>
     <div class="layout-container flex h-full grow">
       {% include 'sidebar.html' %}
       <div class="flex flex-col flex-1">
-        <div class="px-40 flex flex-1 justify-center py-5">
+        <div class="px-10 flex flex-1 py-5">
           <div class="layout-content-container flex flex-col max-w-[1280px] flex-1">
             <div class="flex flex-wrap justify-between gap-3 p-4">
               <div class="flex min-w-72 flex-col gap-3">

--- a/templates/visualize.html
+++ b/templates/visualize.html
@@ -11,7 +11,7 @@
     <div class="layout-container flex h-full grow">
       {% include 'sidebar.html' %}
       <div class="flex flex-col flex-1">
-        <div class="px-40 flex flex-1 justify-center py-5">
+        <div class="px-10 flex flex-1 py-5">
           <div class="layout-content-container flex flex-col max-w-[1280px] flex-1">
             <div class="flex flex-wrap justify-between gap-3 p-4">
               <div class="flex min-w-72 flex-col gap-3">

--- a/templates/warnings.html
+++ b/templates/warnings.html
@@ -11,7 +11,7 @@
     <div class="layout-container flex h-full grow">
       {% include 'sidebar.html' %}
       <div class="flex flex-col flex-1">
-        <div class="px-40 flex flex-1 justify-center py-5">
+        <div class="px-10 flex flex-1 py-5">
           <div class="layout-content-container flex flex-col max-w-[1280px] flex-1">
             <div class="flex flex-wrap justify-between gap-3 p-4">
               <div class="flex min-w-72 flex-col gap-3">


### PR DESCRIPTION
## Summary
- adjust padding so pages align content to the left
- add CSS to keep the header row and first column of the similarity table visible while scrolling

## Testing
- `python -m py_compile app.py check_schema.py components/__init__.py create_syllabus.py`

------
https://chatgpt.com/codex/tasks/task_e_6845f66a85188329841d3b825147a1a0