### PR TITLE
Add dependency graph page

### DIFF
--- a/app.py
+++ b/app.py
@@ -520,6 +520,17 @@ def dependency_list():
     return render_template("dependency_list.html", courses=info)
 
 
+@app.route("/dependency_graph")
+def dependency_graph():
+    """Display a force-directed graph of course dependencies."""
+    graph = build_course_graph()
+    nodes = [{"id": n} for n in graph.nodes]
+    links = [{"source": u, "target": v} for u, v in graph.edges]
+    return render_template(
+        "dependency_graph.html", nodes=nodes, links=links
+    )
+
+
 @app.route("/similarity")
 def similarity():
     """Render similarity page. Actual computation happens over WebSocket."""

--- a/static/dependency_graph.js
+++ b/static/dependency_graph.js
@@ -1,0 +1,94 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const nodes = JSON.parse(document.getElementById('nodes-data').textContent);
+  const links = JSON.parse(document.getElementById('links-data').textContent);
+  const container = document.getElementById('graph');
+  const width = container.clientWidth || 800;
+  const height = container.clientHeight || 600;
+
+  const svg = d3
+    .select(container)
+    .append('svg')
+    .attr('width', width)
+    .attr('height', height);
+
+  svg
+    .append('defs')
+    .append('marker')
+    .attr('id', 'arrow')
+    .attr('viewBox', '0 -5 10 10')
+    .attr('refX', 15)
+    .attr('refY', 0)
+    .attr('markerWidth', 6)
+    .attr('markerHeight', 6)
+    .attr('orient', 'auto')
+    .append('path')
+    .attr('d', 'M0,-5L10,0L0,5')
+    .attr('fill', '#999');
+
+  const simulation = d3
+    .forceSimulation(nodes)
+    .force('link', d3.forceLink(links).id((d) => d.id).distance(150))
+    .force('charge', d3.forceManyBody().strength(-400))
+    .force('center', d3.forceCenter(width / 2, height / 2));
+
+  const link = svg
+    .append('g')
+    .attr('stroke', '#999')
+    .attr('stroke-opacity', 0.6)
+    .selectAll('line')
+    .data(links)
+    .join('line')
+    .attr('stroke-width', 1.5)
+    .attr('marker-end', 'url(#arrow)');
+
+  const node = svg
+    .append('g')
+    .selectAll('g')
+    .data(nodes)
+    .join('g')
+    .call(
+      d3
+        .drag()
+        .on('start', dragstarted)
+        .on('drag', dragged)
+        .on('end', dragended)
+    );
+
+  node
+    .append('circle')
+    .attr('r', 40)
+    .attr('fill', '#69b3a2');
+
+  node
+    .append('text')
+    .attr('text-anchor', 'middle')
+    .attr('dy', 4)
+    .text((d) => d.id);
+
+  simulation.on('tick', () => {
+    link
+      .attr('x1', (d) => d.source.x)
+      .attr('y1', (d) => d.source.y)
+      .attr('x2', (d) => d.target.x)
+      .attr('y2', (d) => d.target.y);
+
+    node.attr('transform', (d) => `translate(${d.x},${d.y})`);
+  });
+
+  function dragstarted(event, d) {
+    if (!event.active) simulation.alphaTarget(0.3).restart();
+    d.fx = d.x;
+    d.fy = d.y;
+  }
+
+  function dragged(event, d) {
+    d.fx = event.x;
+    d.fy = event.y;
+  }
+
+  function dragended(event, d) {
+    if (!event.active) simulation.alphaTarget(0);
+    d.fx = null;
+    d.fy = null;
+  }
+});

--- a/templates/dependency_graph.html
+++ b/templates/dependency_graph.html
@@ -1,0 +1,33 @@
+<html>
+<head>
+  <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="" />
+  <link rel="stylesheet" as="style" onload="this.rel='stylesheet'" href="https://fonts.googleapis.com/css2?display=swap&family=Inter:wght@400;500;700;900&family=Noto+Sans:wght@400;500;700;900" />
+  <title>Syllabus</title>
+  <link rel="icon" type="image/x-icon" href="data:image/x-icon;base64," />
+  <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.5/d3.min.js"></script>
+</head>
+<body>
+  <div class="relative flex size-full min-h-screen flex-col bg-white group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;'>
+    <div class="layout-container flex h-full grow">
+      {% include 'sidebar.html' %}
+      <div class="flex flex-col flex-1">
+        <div class="px-10 flex flex-1 py-5">
+          <div class="layout-content-container flex flex-col max-w-[1280px] flex-1">
+            <div class="flex flex-wrap justify-between gap-3 p-4">
+              <div class="flex min-w-72 flex-col gap-3">
+                <p class="text-[#111518] tracking-light text-[32px] font-bold leading-tight">Dependency graph</p>
+                <p class="text-[#60768a] text-sm font-normal leading-normal">Interactive visualization of course dependencies.</p>
+              </div>
+            </div>
+            <div id="graph" class="w-full h-[600px]"></div>
+            <script id="nodes-data" type="application/json">{{ nodes|tojson }}</script>
+            <script id="links-data" type="application/json">{{ links|tojson }}</script>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <script src="{{ url_for('static', filename='dependency_graph.js') }}"></script>
+</body>
+</html>

--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -16,6 +16,9 @@
   <a class="flex items-center text-[#141414] text-sm font-medium leading-normal" href="/dependency_list">
     <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg>&nbsp;<span>Dependency list</span>
   </a>
+  <a class="flex items-center text-[#141414] text-sm font-medium leading-normal" href="/dependency_graph">
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M12 2v4m0 12v4m10-10h-4M6 12H2m15.657-7.657l-2.829 2.829M8.172 15.828l-2.829 2.829m0-13.657l2.829 2.829m10.627 10.627l2.829 2.829"/></svg>&nbsp;<span>Dependency graph</span>
+  </a>
   <a class="flex items-center text-[#141414] text-sm font-medium leading-normal" href="/similarity">
     <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>&nbsp;<span>Course Similarity</span>
   </a>


### PR DESCRIPTION
## Summary
- add a new sidebar link
- implement `/dependency_graph` route
- provide force directed graph rendering with D3

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6845fee372d88329ab7c3650742b6802