### PR TITLE
Improve dependency graph UX

### DIFF
--- a/static/dependency_graph.js
+++ b/static/dependency_graph.js
@@ -4,12 +4,15 @@ document.addEventListener('DOMContentLoaded', () => {
   const container = document.getElementById('graph');
   const width = container.clientWidth || 800;
   const height = container.clientHeight || 600;
+  const radius = 40;
 
   const svg = d3
     .select(container)
     .append('svg')
     .attr('width', width)
     .attr('height', height);
+
+  const g = svg.append('g');
 
   svg
     .append('defs')
@@ -31,7 +34,7 @@ document.addEventListener('DOMContentLoaded', () => {
     .force('charge', d3.forceManyBody().strength(-400))
     .force('center', d3.forceCenter(width / 2, height / 2));
 
-  const link = svg
+  const link = g
     .append('g')
     .attr('stroke', '#999')
     .attr('stroke-opacity', 0.6)
@@ -41,7 +44,7 @@ document.addEventListener('DOMContentLoaded', () => {
     .attr('stroke-width', 1.5)
     .attr('marker-end', 'url(#arrow)');
 
-  const node = svg
+  const node = g
     .append('g')
     .selectAll('g')
     .data(nodes)
@@ -66,6 +69,11 @@ document.addEventListener('DOMContentLoaded', () => {
     .text((d) => d.id);
 
   simulation.on('tick', () => {
+    nodes.forEach((d) => {
+      d.x = Math.max(radius, Math.min(width - radius, d.x));
+      d.y = Math.max(radius, Math.min(height - radius, d.y));
+    });
+
     link
       .attr('x1', (d) => d.source.x)
       .attr('y1', (d) => d.source.y)
@@ -74,6 +82,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
     node.attr('transform', (d) => `translate(${d.x},${d.y})`);
   });
+
+  svg.call(
+    d3.zoom().scaleExtent([0.5, 5]).on('zoom', (event) => {
+      g.attr('transform', event.transform);
+    })
+  );
 
   function dragstarted(event, d) {
     if (!event.active) simulation.alphaTarget(0.3).restart();


### PR DESCRIPTION
## Summary
- add zoom support to `dependency_graph.js`
- keep nodes inside canvas while simulating

## Testing
- `python3 check_schema.py`

------
https://chatgpt.com/codex/tasks/task_e_68460105025483299dbc5f13afd3c334