### PR TITLE
Fix arrowheads in dependency graph

### DIFF
--- a/static/dependency_graph.js
+++ b/static/dependency_graph.js
@@ -25,8 +25,9 @@ document.addEventListener('DOMContentLoaded', () => {
     .attr('markerHeight', 6)
     .attr('orient', 'auto')
     .append('path')
-    .attr('d', 'M0,-5L10,0L0,5')
-    .attr('fill', '#999');
+    .attr('d', 'M0,-5L10,0L0,5Z')
+    .attr('fill', '#999')
+    .attr('stroke', 'none');
 
   const simulation = d3
     .forceSimulation(nodes)


### PR DESCRIPTION
## Summary
- fix D3 marker path so arrows appear

## Testing
- `python3 check_schema.py`

------
https://chatgpt.com/codex/tasks/task_e_68460920056083298f2978c56963489e