### PR TITLE
Enhance similarity visuals and graph layout

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ ruamel.yaml==0.18.2
 networkx
 sentence-transformers
 numpy
+
+matplotlib

--- a/similarity.yml
+++ b/similarity.yml
@@ -1,0 +1,2 @@
+courses: []
+matrix: []

--- a/static/dependency_graph.js
+++ b/static/dependency_graph.js
@@ -1,6 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   const nodes = JSON.parse(document.getElementById('nodes-data').textContent);
   const links = JSON.parse(document.getElementById('links-data').textContent);
+  const simLinks = JSON.parse(document.getElementById('sim-links-data').textContent);
   const container = document.getElementById('graph');
   const width = container.clientWidth || 800;
   const height = container.clientHeight || 600;
@@ -30,7 +31,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const simulation = d3
     .forceSimulation(nodes)
-    .force('link', d3.forceLink(links).id((d) => d.id).distance(150))
+    .force('dep', d3.forceLink(links).id((d) => d.id).distance(150))
+    .force('sim', d3.forceLink(simLinks).id((d) => d.id).distance((d) => d.distance).strength(0.2))
     .force('charge', d3.forceManyBody().strength(-400))
     .force('center', d3.forceCenter(width / 2, height / 2));
 
@@ -69,10 +71,6 @@ document.addEventListener('DOMContentLoaded', () => {
     .text((d) => d.id);
 
   simulation.on('tick', () => {
-    nodes.forEach((d) => {
-      d.x = Math.max(radius, Math.min(width - radius, d.x));
-      d.y = Math.max(radius, Math.min(height - radius, d.y));
-    });
 
     link
       .attr('x1', (d) => d.source.x)

--- a/static/similarity.js
+++ b/static/similarity.js
@@ -5,22 +5,10 @@ const bodyEl = document.getElementById('simBody');
 const tableEl = document.getElementById('simTable');
 const loadingEl = document.getElementById('loading');
 const progressEl = document.getElementById('progress');
+const recalcBtn = document.getElementById('recalcBtn');
+const initData = JSON.parse(document.getElementById('init-data').textContent);
 
-socket.on('connect', () => {
-  socket.emit('start_similarity');
-});
-
-socket.on('similarity_progress', (data) => {
-  if (progressEl) {
-    progressEl.textContent = data.progress + '%';
-  }
-});
-
-socket.on('similarity_result', (data) => {
-  loadingEl.style.display = 'none';
-  if (progressEl) {
-    progressEl.textContent = '100%';
-  }
+function buildTable(data) {
   tableEl.classList.remove('hidden');
   headEl.innerHTML = '';
   bodyEl.innerHTML = '';
@@ -43,21 +31,39 @@ socket.on('similarity_result', (data) => {
     th.className = 'border px-2 py-1 text-left whitespace-nowrap';
     th.textContent = data.courses[idx];
     tr.appendChild(th);
-    row.forEach((val) => {
+    row.forEach((val, j) => {
       const td = document.createElement('td');
       td.className = 'border px-2 py-1 text-center';
-      if (val > 0.8) {
-        td.classList.add('bg-red-300');
-      } else if (val > 0.6) {
-        td.classList.add('bg-orange-300');
-      } else {
-        td.classList.add('bg-gray-200');
+      if (data.colors && data.colors[idx] && data.colors[idx][j]) {
+        td.style.backgroundColor = data.colors[idx][j];
       }
       td.textContent = val.toFixed(2);
       tr.appendChild(td);
     });
     bodyEl.appendChild(tr);
   });
+}
+
+buildTable(initData);
+
+recalcBtn.addEventListener('click', () => {
+  loadingEl.classList.remove('hidden');
+  progressEl.textContent = '0%';
+  socket.emit('start_similarity', { force: true });
+});
+
+socket.on('similarity_progress', (data) => {
+  if (progressEl) {
+    progressEl.textContent = data.progress + '%';
+  }
+});
+
+socket.on('similarity_result', (data) => {
+  loadingEl.classList.add('hidden');
+  if (progressEl) {
+    progressEl.textContent = '100%';
+  }
+  buildTable(data);
 });
 
 window.addEventListener('beforeunload', () => {

--- a/templates/dependency_graph.html
+++ b/templates/dependency_graph.html
@@ -23,6 +23,7 @@
             <div id="graph" class="w-full h-[600px]"></div>
             <script id="nodes-data" type="application/json">{{ nodes|tojson }}</script>
             <script id="links-data" type="application/json">{{ links|tojson }}</script>
+            <script id="sim-links-data" type="application/json">{{ sim_links|tojson }}</script>
           </div>
         </div>
       </div>

--- a/templates/similarity.html
+++ b/templates/similarity.html
@@ -45,9 +45,12 @@
                   greater content overlap.</p>
               </div>
             </div>
+            <div class="flex items-center gap-4 p-4">
+              <button id="recalcBtn" class="rounded bg-gray-200 px-3 py-1 text-sm">Recalculate</button>
+            </div>
             <div class="overflow-auto pr-4">
-              <div id="loading" class="p-4">Calculating <span id="progress">0%</span></div>
-              <table id="simTable" class="min-w-full border-collapse text-xs hidden">
+              <div id="loading" class="p-4 hidden">Calculating <span id="progress">0%</span></div>
+              <table id="simTable" class="min-w-full border-collapse text-xs">
                 <thead id="simHead"></thead>
                 <tbody id="simBody"></tbody>
               </table>
@@ -57,6 +60,7 @@
       </div>
     </div>
   </div>
+  <script id="init-data" type="application/json">{{ data|tojson }}</script>
   <script src="https://cdn.socket.io/4.6.1/socket.io.min.js"></script>
   <script src="{{ url_for('static', filename='similarity.js') }}"></script>
 </body>


### PR DESCRIPTION
## Summary
- cache course similarity in `similarity.yml`
- provide helper to recolor similarity matrix
- allow recalculation from UI
- update dependency graph to use similarity distances and remove canvas limits
- include matplotlib in requirements

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68460902faac8329aa877ad4643c7fef