### PR TITLE
Fix layout width and warning display

### DIFF
--- a/templates/dependency_graph.html
+++ b/templates/dependency_graph.html
@@ -13,7 +13,7 @@
       {% include 'sidebar.html' %}
       <div class="flex flex-col flex-1">
         <div class="px-10 flex flex-1 py-5">
-          <div class="layout-content-container flex flex-col max-w-[1280px] flex-1">
+          <div class="layout-content-container flex flex-col flex-1">
             <div class="flex flex-wrap justify-between gap-3 p-4">
               <div class="flex min-w-72 flex-col gap-3">
                 <p class="text-[#111518] tracking-light text-[32px] font-bold leading-tight">Dependency graph</p>

--- a/templates/similarity.html
+++ b/templates/similarity.html
@@ -36,7 +36,7 @@
       {% include 'sidebar.html' %}
       <div class="flex flex-col flex-1">
         <div class="px-10 flex flex-1 py-5">
-          <div class="layout-content-container flex flex-col max-w-[1280px] flex-1">
+          <div class="layout-content-container flex flex-col flex-1">
             <div class="flex flex-wrap justify-between gap-3 p-4">
               <div class="flex min-w-72 flex-col gap-3">
                 <p class="text-[#111518] tracking-light text-[32px] font-bold leading-tight">Course Similarity</p>
@@ -48,7 +48,7 @@
             <div class="flex items-center gap-4 p-4">
               <button id="recalcBtn" class="rounded bg-gray-200 px-3 py-1 text-sm">Recalculate</button>
             </div>
-            <div class="overflow-y-auto max-w-[1100px] m-4">
+            <div class="overflow-y-auto w-full m-4">
               <div id="loading" class="p-4 hidden">Calculating <span id="progress">0%</span></div>
               <table id="simTable" class="min-w-full border-collapse text-xs">
                 <thead id="simHead"></thead>

--- a/templates/warnings.html
+++ b/templates/warnings.html
@@ -46,10 +46,23 @@
               <div class="flex items-start gap-3 rounded-lg p-4 {% if error.ignored %}bg-gray-100{% else %}bg-red-50{% endif %}">
                 <div class="size-5 text-red-500">
                   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m0 3.75h.008v.008H12V16.5zm0-12a9 9 0 100 18 9 9 0 000-18z"/>
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M9.75 9.75l4.5 4.5m0-4.5l-4.5 4.5M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
                   </svg>
                 </div>
-                <p class="text-sm text-red-700">{{ error.message }}</p>
+                <p class="flex-1 text-sm {% if error.ignored %}text-gray-400{% else %}text-red-700{% endif %}">{{ error.text }}</p>
+                <input type="checkbox" data-error="{{ error.text }}" class="h-5 w-5 ml-2 rounded border-[#dbdbdb] border-2 bg-transparent checked:bg-red-500 checked:border-red-500 checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:outline-none" {% if error.ignored %}checked{% endif %} />
+              </div>
+              {% endfor %}
+
+              {% for warning in warnings %}
+              <div class="flex items-start gap-3 rounded-lg p-4 {% if warning.ignored %}bg-gray-100{% else %}bg-yellow-50{% endif %}">
+                <div class="size-5 text-yellow-500">
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                  </svg>
+                </div>
+                <p class="flex-1 text-sm {% if warning.ignored %}text-gray-400{% else %}text-yellow-700{% endif %}">{{ warning.text }}</p>
+                <input type="checkbox" data-warning="{{ warning.text }}" class="h-5 w-5 ml-2 rounded border-[#dbdbdb] border-2 bg-transparent checked:bg-yellow-500 checked:border-yellow-500 checked:bg-[image:--checkbox-tick-svg] focus:ring-0 focus:outline-none" {% if warning.ignored %}checked{% endif %} />
               </div>
               {% endfor %}
             </div>


### PR DESCRIPTION
## Summary
- make dependency graph and similarity matrix use full width
- restore warning and error messages with ignore checkboxes

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684697378b088329a338ce6a8d22cdbc