### PR TITLE
Add dependency tree view

### DIFF
--- a/app.py
+++ b/app.py
@@ -490,6 +490,24 @@ def build_course_graph():
     return g
 
 
+def build_dependency_tree():
+    """Return a hierarchical representation of course dependencies."""
+    graph = build_course_graph()
+
+    def build_node(course, seen):
+        if course in seen:
+            return {"name": course, "children": []}
+        seen.add(course)
+        children = [build_node(dep, seen) for dep in graph.successors(course)]
+        seen.remove(course)
+        return {"name": course, "children": children}
+
+    root = {"name": "Courses", "children": []}
+    for course in graph.nodes:
+        root["children"].append(build_node(course, set()))
+    return root
+
+
 def find_circular_dependencies():
     """Return a list of course cycles."""
     graph = build_course_graph()
@@ -591,6 +609,13 @@ def dependency_graph():
     return render_template(
         "dependency_graph.html", nodes=nodes, links=links, sim_links=sim_links
     )
+
+
+@app.route("/dependency_tree")
+def dependency_tree():
+    """Display a tree view of course dependencies."""
+    tree = build_dependency_tree()
+    return render_template("dependency_tree.html", tree=tree)
 
 
 @app.route("/similarity")

--- a/static/dependency_tree.js
+++ b/static/dependency_tree.js
@@ -1,0 +1,51 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const data = JSON.parse(document.getElementById('tree-data').textContent);
+  const container = document.getElementById('tree');
+  const width = container.clientWidth || 1100;
+  const dx = 10;
+  const dy = 200;
+
+  const root = d3.hierarchy(data);
+  const treeLayout = d3.tree().nodeSize([dx, dy]);
+  treeLayout(root);
+
+  const svg = d3
+    .select(container)
+    .append('svg')
+    .attr('width', width)
+    .attr('height', root.height * dx + 100)
+    .attr('viewBox', [0, 0, width, root.height * dx + 100].join(' '));
+
+  const g = svg.append('g').attr('font-family', 'sans-serif').attr('font-size', 10);
+
+  g.append('g')
+    .selectAll('path')
+    .data(root.links())
+    .join('path')
+    .attr('fill', 'none')
+    .attr('stroke', '#555')
+    .attr('stroke-width', 1.5)
+    .attr('d', d3.linkHorizontal()
+      .x(d => d.y)
+      .y(d => d.x)
+    );
+
+  const node = g.append('g')
+    .selectAll('g')
+    .data(root.descendants())
+    .join('g')
+    .attr('transform', d => `translate(${d.y},${d.x})`);
+
+  node.append('circle')
+    .attr('r', 4)
+    .attr('fill', d => d.children ? '#555' : '#999');
+
+  node.append('text')
+    .attr('dy', '0.31em')
+    .attr('x', d => d.children ? -6 : 6)
+    .attr('text-anchor', d => d.children ? 'end' : 'start')
+    .text(d => d.data.name)
+    .clone(true)
+    .lower()
+    .attr('stroke', 'white');
+});

--- a/templates/dependency_tree.html
+++ b/templates/dependency_tree.html
@@ -1,0 +1,32 @@
+<html>
+<head>
+  <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="" />
+  <link rel="stylesheet" as="style" onload="this.rel='stylesheet'" href="https://fonts.googleapis.com/css2?display=swap&family=Inter:wght@400;500;700;900&family=Noto+Sans:wght@400;500;700;900" />
+  <title>Syllabus</title>
+  <link rel="icon" type="image/x-icon" href="data:image/x-icon;base64," />
+  <script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.5/d3.min.js"></script>
+</head>
+<body>
+  <div class="relative flex size-full min-h-screen flex-col bg-white group/design-root overflow-x-hidden" style='font-family: Inter, "Noto Sans", sans-serif;'>
+    <div class="layout-container flex h-full grow">
+      {% include 'sidebar.html' %}
+      <div class="flex flex-col flex-1">
+        <div class="px-10 flex flex-1 py-5">
+          <div class="layout-content-container flex flex-col flex-1">
+            <div class="flex flex-wrap justify-between gap-3 p-4">
+              <div class="flex min-w-72 flex-col gap-3">
+                <p class="text-[#111518] tracking-light text-[32px] font-bold leading-tight">Dependency tree</p>
+                <p class="text-[#60768a] text-sm font-normal leading-normal">Hierarchical view of course dependencies.</p>
+              </div>
+            </div>
+            <div id="tree" class="w-full h-[600px]"></div>
+            <script id="tree-data" type="application/json">{{ tree|tojson }}</script>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <script src="{{ url_for('static', filename='dependency_tree.js') }}"></script>
+</body>
+</html>

--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -19,6 +19,9 @@
   <a class="flex items-center text-[#141414] text-sm font-medium leading-normal" href="/dependency_graph">
     <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M12 2v4m0 12v4m10-10h-4M6 12H2m15.657-7.657l-2.829 2.829M8.172 15.828l-2.829 2.829m0-13.657l2.829 2.829m10.627 10.627l2.829 2.829"/></svg>&nbsp;<span>Dependency graph</span>
   </a>
+  <a class="flex items-center text-[#141414] text-sm font-medium leading-normal" href="/dependency_tree">
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v20M5 9l7-7 7 7"/><path d="M5 15l7 7 7-7"/></svg>&nbsp;<span>Dependency tree</span>
+  </a>
   <a class="flex items-center text-[#141414] text-sm font-medium leading-normal" href="/similarity">
     <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>&nbsp;<span>Course Similarity</span>
   </a>


### PR DESCRIPTION
## Summary
- add `build_dependency_tree` helper and route
- provide new `dependency_tree.html` template and JS
- link dependency tree from the sidebar

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68469a08e3a48329aab1406e0afe766c