### PR TITLE
Add dynamic warning count

### DIFF
--- a/app.py
+++ b/app.py
@@ -679,6 +679,16 @@ def toggle_error():
     update_ignored_error(text, ignore)
     return jsonify({"ok": True})
 
+
+@app.route("/warning_stats")
+def warning_stats():
+    warns, errs = dependency_issues()
+    ignored_warn = set(load_ignored_warnings())
+    ignored_err = set(load_ignored_errors())
+    active_warns = [w for w in warns if w not in ignored_warn]
+    active_errs = [e for e in errs if e not in ignored_err]
+    return jsonify({"warnings": len(active_warns), "errors": len(active_errs)})
+
 @app.route("/remove_course_dependency", methods=["POST"])
 def remove_course_dependency_route():
     data = request.get_json(force=True)

--- a/static/dependencies.js
+++ b/static/dependencies.js
@@ -213,6 +213,10 @@ document.addEventListener('DOMContentLoaded', () => {
   loadDependencies();
 });
 
+socket.on('saved', () => {
+  if (window.updateWarningBadge) window.updateWarningBadge();
+});
+
 commentInput.addEventListener('blur', () => {
   if (!targetSelect.value || !courseSelect.value) return;
   socket.emit('update_comment', {

--- a/static/warning_badge.js
+++ b/static/warning_badge.js
@@ -1,0 +1,13 @@
+function updateWarningBadge() {
+  fetch('/warning_stats')
+    .then((r) => r.json())
+    .then((data) => {
+      const el = document.getElementById('warningsMenuText');
+      if (!el) return;
+      const total = (data.warnings || 0) + (data.errors || 0);
+      el.textContent = total > 0 ? `Warnings (${total})` : 'Warnings';
+    });
+}
+
+document.addEventListener('DOMContentLoaded', updateWarningBadge);
+window.updateWarningBadge = updateWarningBadge;

--- a/static/warnings.js
+++ b/static/warnings.js
@@ -26,6 +26,7 @@ document.addEventListener('DOMContentLoaded', () => {
             wrapper.classList.remove('bg-gray-100');
           }
         }
+        if (window.updateWarningBadge) window.updateWarningBadge();
       });
     });
   });

--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -26,6 +26,7 @@
     <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>&nbsp;<span>Course Similarity</span>
   </a>
   <a class="flex items-center text-[#141414] text-sm font-medium leading-normal" href="/warnings">
-    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>&nbsp;<span>Warnings</span>
+    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>&nbsp;<span id="warningsMenuText">Warnings</span>
   </a>
 </nav>
+<script src="{{ url_for('static', filename='warning_badge.js') }}"></script>


### PR DESCRIPTION
## Summary
- add a `warning_badge.js` helper to update the sidebar
- show the warning count in sidebar.html
- refresh the badge when warnings are toggled
- refresh the badge when dependencies are saved
- expose `/warning_stats` API for the badge

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68469c60b1288329929d6c077516be2a