### PR TITLE
Fix text wrapping in similarity table

### DIFF
--- a/static/similarity.js
+++ b/static/similarity.js
@@ -15,11 +15,11 @@ function buildTable(data) {
 
   const headRow = document.createElement('tr');
   const emptyTh = document.createElement('th');
-  emptyTh.className = 'border px-2 py-1 text-left';
+  emptyTh.className = 'border px-2 py-1 text-left break-words whitespace-normal';
   headRow.appendChild(emptyTh);
   data.courses.forEach((name) => {
     const th = document.createElement('th');
-    th.className = 'border px-2 py-1 text-left';
+    th.className = 'border px-2 py-1 text-left break-words whitespace-normal';
     th.textContent = name;
     headRow.appendChild(th);
   });
@@ -28,12 +28,12 @@ function buildTable(data) {
   data.matrix.forEach((row, idx) => {
     const tr = document.createElement('tr');
     const th = document.createElement('th');
-    th.className = 'border px-2 py-1 text-left';
+    th.className = 'border px-2 py-1 text-left break-words whitespace-normal';
     th.textContent = data.courses[idx];
     tr.appendChild(th);
     row.forEach((val, j) => {
       const td = document.createElement('td');
-      td.className = 'border px-2 py-1 text-center';
+      td.className = 'border px-2 py-1 text-center break-words whitespace-normal';
       if (data.colors && data.colors[idx] && data.colors[idx][j]) {
         td.style.backgroundColor = data.colors[idx][j];
       }

--- a/templates/similarity.html
+++ b/templates/similarity.html
@@ -15,6 +15,12 @@
       z-index: 10;
     }
 
+    #simTable th,
+    #simTable td {
+      white-space: normal;
+      overflow-wrap: anywhere;
+    }
+
     #simTable th:first-child,
     #simTable td:first-child {
       position: sticky;
@@ -51,7 +57,7 @@
               <div id="loading" class="p-4 hidden">Calculating <span id="progress">0%</span></div>
 
               <div class="overflow-auto max-h-[80vh] border rounded">
-                <table id="simTable" class="border-collapse text-xs min-w-max">
+                <table id="simTable" class="border-collapse text-xs w-full">
                   <thead id="simHead"></thead>
                   <tbody id="simBody"></tbody>
                 </table>


### PR DESCRIPTION
## Summary
- allow wrapping for similarity table cells
- update table style to expand width

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6846a44232b083298e9cd257deb3e09b